### PR TITLE
fix: scheduled trigger session_id

### DIFF
--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -162,7 +162,8 @@ export class InfraStack extends Stack {
     scheduledTriggerRule.addTarget(
       new SfnStateMachine(workflow.stateMachine, {
         input: RuleTargetInput.fromObject({
-          session_id: EventField.time,
+          // Use EventField.eventId (UUID format, 36 chars) to meet AgentCore's 33+ character requirement
+          session_id: EventField.eventId,
         }),
       }),
     );
@@ -178,6 +179,7 @@ export class InfraStack extends Stack {
     manualTriggerRule.addTarget(
       new SfnStateMachine(workflow.stateMachine, {
         input: RuleTargetInput.fromObject({
+          // Use EventBridge event-id (UUID format, 36 chars) to meet AgentCore's 33+ character requirement
           session_id: EventField.fromPath('$.id'),
         }),
       }),

--- a/infra/test/eventbridge-rules.spec.ts
+++ b/infra/test/eventbridge-rules.spec.ts
@@ -57,6 +57,23 @@ describe('EventBridge Rules', () => {
       expect(rule.Properties.Targets).toBeDefined();
       expect(rule.Properties.Targets).toHaveLength(1);
     });
+
+    it('should use event-id for session_id to meet AgentCore 33+ character requirement', () => {
+      const rules = template.findResources('AWS::Events::Rule', {
+        Properties: {
+          ScheduleExpression: 'cron(0 6 * * ? *)',
+        },
+      });
+
+      const ruleKey = Object.keys(rules)[0];
+      const rule = rules[ruleKey];
+      const target = rule.Properties.Targets[0];
+
+      expect(target.InputTransformer).toBeDefined();
+      expect(target.InputTransformer.InputPathsMap).toHaveProperty('id');
+      expect(target.InputTransformer.InputPathsMap.id).toBe('$.id');
+      expect(target.InputTransformer.InputTemplate).toContain('"session_id":<id>');
+    });
   });
 
   describe('EventBridge Rules Count', () => {


### PR DESCRIPTION
## Fix scheduled trigger session_id to meet AgentCore requirements

**Problem:** Scheduled trigger was using `EventField.time` which produces a timestamp (~20 chars), causing AgentCore validation error: "Invalid length for parameter runtimeSessionId, value: 20, valid min length: 33"

**Fix:** Changed to `EventField.eventId` which uses EventBridge's auto-generated UUID (36 chars), matching the manual trigger pattern.

**Changes:**
- Updated scheduled trigger to use `EventField.eventId` instead of `EventField.time`
- Added code comments explaining the 33+ character requirement
- Added infrastructure test to validate session_id uses EventBridge event-id (UUID format)

Both triggers now consistently use EventBridge's event-id as session_id, meeting AgentCore's validation requirements.

