### PR TITLE
fix: dependabot warnings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,12 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
-      timezone: "UTC"
+      timezone: "Etc/UTC"
     commit-message:
       prefix: "chore"
       include: "scope"
     labels:
       - "dependencies"
-      - "github-actions"
 
   # Python dependencies (pip)
   - package-ecosystem: "pip"
@@ -22,7 +21,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
-      timezone: "UTC"
+      timezone: "Etc/UTC"
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -48,7 +47,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
-      timezone: "UTC"
+      timezone: "Etc/UTC"
     versioning-strategy: increase
     commit-message:
       prefix: "chore"


### PR DESCRIPTION
This PR fixes few warnings such as:
- missing label `"github-actions"` (removed)
- timezone format `"UTC"` (changed to allowed value `"Etc/UTC"`)
