### PR TITLE
feat: BedrockAgentCore context for session

### DIFF
--- a/infra/lambda/agent_invoker.py
+++ b/infra/lambda/agent_invoker.py
@@ -31,7 +31,6 @@ aws_region = os.environ.get("AWS_REGION", "us-east-1")
 def handler(event, context):
     """Lambda handler to invoke Bedrock AgentCore runtime"""
     session_id = event["session_id"]
-    prompt = event.get("prompt", "Check my resources and let me know if they're overprovisioned")
 
     logger.info("Lambda started", sessionId=session_id)
 
@@ -49,10 +48,12 @@ def handler(event, context):
         trace_id = get_tracer_id()
 
         # Invoke AgentCore runtime
+        # Note: Empty payload is intentional - session_id is in the context
+        # into the context by AgentCore and accessed via context.session_id
         invoke_params = {
             "agentRuntimeArn": agent_runtime_arn,
             "runtimeSessionId": session_id,
-            "payload": json.dumps({"prompt": prompt, "session_id": session_id}),
+            "payload": json.dumps({}),
         }
 
         # Links Lambda X-Ray traces with AgentCore for end-to-end observability in GenAI console
@@ -62,7 +63,9 @@ def handler(event, context):
         response = bedrock_agentcore.invoke_agent_runtime(**invoke_params)
 
         logger.info(
-            "AgentCore responded", sessionId=response.get("runtimeSessionId"), status=response.get("statusCode")
+            "AgentCore responded",
+            sessionId=response.get("runtimeSessionId"),
+            status=response.get("statusCode"),
         )
 
         record_event(
@@ -73,7 +76,10 @@ def handler(event, context):
             region_name=aws_region,
         )
 
-        return {"status": response.get("statusCode"), "sessionId": response.get("runtimeSessionId")}
+        return {
+            "status": response.get("statusCode"),
+            "sessionId": response.get("runtimeSessionId"),
+        }
 
     except Exception as e:
         logger.error("AgentCore failed", error=str(e), sessionId=session_id)

--- a/tests/test_agent_invoke.py
+++ b/tests/test_agent_invoke.py
@@ -1,10 +1,18 @@
 """Unit tests for the agent invoke function with fire-and-forget async behavior."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from src.agents.main import invoke
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock RequestContext with session_id."""
+    context = MagicMock()
+    context.session_id = "session-456"
+    return context
 
 
 class TestInvokeFunction:
@@ -13,12 +21,12 @@ class TestInvokeFunction:
     @pytest.mark.asyncio
     @patch("src.agents.main.record_event")
     @patch("asyncio.create_task")
-    async def test_successful_task_creation(self, mock_create_task, mock_record_event):
+    async def test_successful_task_creation(self, mock_create_task, mock_record_event, mock_context):
         """Test successful task creation: invoke returns immediate success message."""
         mock_create_task.return_value = AsyncMock()
-        payload = {"prompt": "hello", "session_id": "session-456"}
+        payload = {"prompt": "hello"}
 
-        result = await invoke(payload)
+        result = await invoke(payload, mock_context)
 
         assert "Started processing request for session session-456" in result["message"]
         assert result["session_id"] == "session-456"
@@ -27,38 +35,39 @@ class TestInvokeFunction:
     @pytest.mark.asyncio
     @patch("src.agents.main.record_event")
     @patch("asyncio.create_task")
-    async def test_task_creation_failure(self, mock_create_task, mock_record_event):
+    async def test_task_creation_failure(self, mock_create_task, mock_record_event, mock_context):
         """Test task creation failure: invoke returns error message."""
         mock_create_task.side_effect = Exception("Task creation failed")
-        payload = {"prompt": "hello", "session_id": "session-456"}
+        payload = {"prompt": "hello"}
 
-        result = await invoke(payload)
+        result = await invoke(payload, mock_context)
 
         assert "Error starting background processing: Task creation failed" in result["error"]
 
     @pytest.mark.asyncio
     @patch("src.agents.main.record_event")
     @patch("asyncio.create_task")
-    async def test_default_prompt_when_missing(self, mock_create_task, mock_record_event):
+    async def test_default_prompt_when_missing(self, mock_create_task, mock_record_event, mock_context):
         """Test that default prompt 'Hello' is used when prompt is missing from payload."""
         mock_create_task.return_value = AsyncMock()
-        payload = {"session_id": "session-456"}
+        payload = {}
 
-        result = await invoke(payload)
+        result = await invoke(payload, mock_context)
 
         assert "Started processing request for session session-456" in result["message"]
 
     @pytest.mark.asyncio
     @patch("src.agents.main.record_event")
     @patch("asyncio.create_task")
-    async def test_default_session_id_when_missing(self, mock_create_task, mock_record_event):
-        """Test that default session_id from environment is used when missing from payload."""
+    async def test_session_id_from_context(self, mock_create_task, mock_record_event, mock_context):
+        """Test that session_id is retrieved from context."""
         mock_create_task.return_value = AsyncMock()
         payload = {"prompt": "test"}
 
-        result = await invoke(payload)
+        result = await invoke(payload, mock_context)
 
-        assert "Started processing request for session local-dev-session" in result["message"]
+        assert "Started processing request for session session-456" in result["message"]
+        assert result["session_id"] == "session-456"
 
 
 class TestBackgroundTaskIntegration:
@@ -67,12 +76,12 @@ class TestBackgroundTaskIntegration:
     @pytest.mark.asyncio
     @patch("src.agents.main.record_event")
     @patch("asyncio.create_task")
-    async def test_background_task_is_started(self, mock_create_task, mock_record_event):
+    async def test_background_task_is_started(self, mock_create_task, mock_record_event, mock_context):
         """Test that background task is started when invoke is called."""
         mock_create_task.return_value = AsyncMock()
-        payload = {"prompt": "hello", "session_id": "session-456"}
+        payload = {"prompt": "hello"}
 
-        result = await invoke(payload)
+        result = await invoke(payload, mock_context)
 
         assert (
             result["message"]
@@ -91,15 +100,17 @@ class TestBackgroundTaskErrorHandling:
     @patch("asyncio.create_task")
     @patch("src.agents.main.logger")
     @patch("src.agents.main.analysis_agent")
-    async def test_credentials_error_through_invoke(self, mock_agent, mock_logger, mock_create_task, mock_record_event):
+    async def test_credentials_error_through_invoke(
+        self, mock_agent, mock_logger, mock_create_task, mock_record_event, mock_context
+    ):
         """Test NoCredentialsError handling through invoke integration."""
         from botocore.exceptions import NoCredentialsError
 
         mock_create_task.return_value = AsyncMock()
         mock_agent.invoke_async.side_effect = NoCredentialsError()
-        payload = {"prompt": "hello", "session_id": "session-456"}
+        payload = {"prompt": "hello"}
 
-        result = await invoke(payload)
+        result = await invoke(payload, mock_context)
 
         assert "Started processing request for session session-456" in result["message"]
         assert result["status"] == "started"
@@ -110,18 +121,21 @@ class TestBackgroundTaskErrorHandling:
     @patch("asyncio.create_task")
     @patch("src.agents.main.logger")
     @patch("src.agents.main.analysis_agent")
-    async def test_throttling_error_through_invoke(self, mock_agent, mock_logger, mock_create_task, mock_record_event):
+    async def test_throttling_error_through_invoke(
+        self, mock_agent, mock_logger, mock_create_task, mock_record_event, mock_context
+    ):
         """Test ThrottlingException handling through invoke integration."""
         from botocore.exceptions import ClientError
 
         throttling_error = ClientError(
-            {"Error": {"Code": "ThrottlingException", "Message": "Rate exceeded"}}, "InvokeModel"
+            {"Error": {"Code": "ThrottlingException", "Message": "Rate exceeded"}},
+            "InvokeModel",
         )
         mock_create_task.return_value = AsyncMock()
         mock_agent.invoke_async.side_effect = throttling_error
-        payload = {"prompt": "hello", "session_id": "session-456"}
+        payload = {"prompt": "hello"}
 
-        result = await invoke(payload)
+        result = await invoke(payload, mock_context)
 
         assert "Started processing request for session session-456" in result["message"]
         assert result["status"] == "started"
@@ -133,19 +147,20 @@ class TestBackgroundTaskErrorHandling:
     @patch("src.agents.main.logger")
     @patch("src.agents.main.analysis_agent")
     async def test_access_denied_error_through_invoke(
-        self, mock_agent, mock_logger, mock_create_task, mock_record_event
+        self, mock_agent, mock_logger, mock_create_task, mock_record_event, mock_context
     ):
         """Test AccessDeniedException handling through invoke integration."""
         from botocore.exceptions import ClientError
 
         access_denied_error = ClientError(
-            {"Error": {"Code": "AccessDeniedException", "Message": "Access denied"}}, "InvokeModel"
+            {"Error": {"Code": "AccessDeniedException", "Message": "Access denied"}},
+            "InvokeModel",
         )
         mock_create_task.return_value = AsyncMock()
         mock_agent.invoke_async.side_effect = access_denied_error
-        payload = {"prompt": "hello", "session_id": "session-456"}
+        payload = {"prompt": "hello"}
 
-        result = await invoke(payload)
+        result = await invoke(payload, mock_context)
 
         assert "Started processing request for session session-456" in result["message"]
         assert result["status"] == "started"
@@ -156,13 +171,15 @@ class TestBackgroundTaskErrorHandling:
     @patch("asyncio.create_task")
     @patch("src.agents.main.logger")
     @patch("src.agents.main.analysis_agent")
-    async def test_generic_exception_through_invoke(self, mock_agent, mock_logger, mock_create_task, mock_record_event):
+    async def test_generic_exception_through_invoke(
+        self, mock_agent, mock_logger, mock_create_task, mock_record_event, mock_context
+    ):
         """Test generic Exception handling through invoke integration."""
         mock_create_task.return_value = AsyncMock()
         mock_agent.invoke_async.side_effect = Exception("Unexpected error")
-        payload = {"prompt": "hello", "session_id": "session-456"}
+        payload = {"prompt": "hello"}
 
-        result = await invoke(payload)
+        result = await invoke(payload, mock_context)
 
         assert "Started processing request for session session-456" in result["message"]
         assert result["status"] == "started"
@@ -174,15 +191,15 @@ class TestBackgroundTaskErrorHandling:
     @patch("src.agents.main.logger")
     @patch("src.agents.main.analysis_agent")
     async def test_successful_agent_response_through_invoke(
-        self, mock_agent, mock_logger, mock_create_task, mock_record_event
+        self, mock_agent, mock_logger, mock_create_task, mock_record_event, mock_context
     ):
         """Test successful agent response through invoke integration."""
         mock_create_task.return_value = AsyncMock()
         mock_response = type("MockResponse", (), {"message": "Hello, how can I help?"})()
         mock_agent.invoke_async.return_value = mock_response
-        payload = {"prompt": "hello", "session_id": "session-456"}
+        payload = {"prompt": "hello"}
 
-        result = await invoke(payload)
+        result = await invoke(payload, mock_context)
 
         assert "Started processing request for session session-456" in result["message"]
         assert result["status"] == "started"


### PR DESCRIPTION
**Issue number:** closes #<replace with issue number>

## Summary
Refactored session management to use the official BedrockAgentCore context pattern instead of passing session_id through the payload.
### Changes
- Updated invoke() entrypoint to accept RequestContext parameter and retrieve session_id from context.session_id
- Changed agent_invoker Lambda to pass empty payload {} - session_id is now passed via the runtimeSessionId parameter
- Removed unused module-level session_id environment variable fallback
- Removed unused prompt variable from agent_invoker handler
- Updated all tests to use mock_context fixture with proper session_id injection

### Tests
- Manual Test Done.

- Journal Screenshot
<img width="1156" height="508" alt="Screenshot 2025-11-26 at 15 50 30" src="https://github.com/user-attachments/assets/e0df89be-49b7-4fc3-8de9-f4f1b9640ff5" />
<img width="1156" height="451" alt="Screenshot 2025-11-26 at 15 51 05" src="https://github.com/user-attachments/assets/51b392b3-687a-4d14-901e-5adfc29799e8" />



### User experience

> Please share what the user experience looks like before and after this change

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-samples/sample-agentic-cost-optimizer/blob/main/CONTRIBUTING.md
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Add a PR title that follows the conventional commit semantics - http://conventionalcommits.org
- If relevant, add tests that prove that the change is effective and works
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.