### PR TITLE
feat: IAM policies for DynamoDB and S3.

### DIFF
--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -76,7 +76,14 @@ export class InfraStack extends Stack {
       },
     });
 
-    agentDataBucket.grantReadWrite(this.agent.runtime.role);
+    this.agent.runtime.role.addToPrincipalPolicy(
+      new PolicyStatement({
+        sid: 'S3AgentRuntimeAccess',
+        effect: Effect.ALLOW,
+        actions: ['s3:GetObject', 's3:PutObject'],
+        resources: [`${agentDataBucket.bucketArn}/*`],
+      }),
+    );
 
     // Least privilege: Agent runtime only needs to write events (PutItem only - no updates)
     this.agent.runtime.role.addToPrincipalPolicy(

--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -1,11 +1,11 @@
-import { CfnOutput, Duration, RemovalPolicy, Stack, type StackProps } from 'aws-cdk-lib';
+import { CfnOutput, Duration, Fn, RemovalPolicy, Stack, type StackProps } from 'aws-cdk-lib';
 import { NagSuppressions } from 'cdk-nag';
 import { Construct } from 'constructs';
 
 import { AttributeType, BillingMode, Table } from 'aws-cdk-lib/aws-dynamodb';
 import { EventField, EventPattern, Rule, RuleTargetInput, Schedule } from 'aws-cdk-lib/aws-events';
 import { SfnStateMachine } from 'aws-cdk-lib/aws-events-targets';
-import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { ArnPrincipal, Effect, PolicyDocument, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Code, Function, LayerVersion, Runtime, Tracing } from 'aws-cdk-lib/aws-lambda';
 import { Bucket, BucketEncryption } from 'aws-cdk-lib/aws-s3';
 
@@ -76,22 +76,13 @@ export class InfraStack extends Stack {
       },
     });
 
-    this.agent.runtime.role.addToPrincipalPolicy(
+    agentDataBucket.addToResourcePolicy(
       new PolicyStatement({
-        sid: 'S3AgentRuntimeAccess',
+        sid: 'AllowAgentRuntimeAccess',
         effect: Effect.ALLOW,
+        principals: [new ArnPrincipal(this.agent.runtime.role.roleArn)],
         actions: ['s3:GetObject', 's3:PutObject'],
         resources: [`${agentDataBucket.bucketArn}/*`],
-      }),
-    );
-
-    // Least privilege: Agent runtime only needs to write events (PutItem only - no updates)
-    this.agent.runtime.role.addToPrincipalPolicy(
-      new PolicyStatement({
-        sid: 'DynamoDBAgentRuntimeAccess',
-        effect: Effect.ALLOW,
-        actions: ['dynamodb:PutItem'],
-        resources: [agentsTable.tableArn],
       }),
     );
 
@@ -159,16 +150,6 @@ export class InfraStack extends Stack {
       }),
     );
 
-    // Least privilege: Agent invoker only needs to write invocation events
-    agentInvokerFunction.addToRolePolicy(
-      new PolicyStatement({
-        sid: 'DynamoDBAgentInvokerAccess',
-        effect: Effect.ALLOW,
-        actions: ['dynamodb:PutItem'],
-        resources: [agentsTable.tableArn],
-      }),
-    );
-
     const workflow = new Workflow(this, 'AgentWorkflow', {
       agentInvokerFunction,
       journalTable: agentsTable,
@@ -176,6 +157,46 @@ export class InfraStack extends Stack {
       ttlDays: InfraConfig.ttlDays,
       lambdaLogLevel: InfraConfig.lambdaLogLevel,
     });
+
+    agentsTable.addToResourcePolicy(
+      new PolicyStatement({
+        sid: 'AllowAgentRuntimePutItem',
+        effect: Effect.ALLOW,
+        principals: [new ArnPrincipal(this.agent.runtime.role.roleArn)],
+        actions: ['dynamodb:PutItem'],
+        resources: [Fn.sub('arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/agents-table-${environment}', { environment })],
+      }),
+    );
+
+    agentsTable.addToResourcePolicy(
+      new PolicyStatement({
+        sid: 'AllowAgentInvokerPutItem',
+        effect: Effect.ALLOW,
+        principals: [new ArnPrincipal(agentInvokerFunction.role!.roleArn)],
+        actions: ['dynamodb:PutItem'],
+        resources: [Fn.sub('arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/agents-table-${environment}', { environment })],
+      }),
+    );
+
+    agentsTable.addToResourcePolicy(
+      new PolicyStatement({
+        sid: 'AllowSessionInitializerPutItem',
+        effect: Effect.ALLOW,
+        principals: [new ArnPrincipal(workflow.sessionInitializerFunction.role!.roleArn)],
+        actions: ['dynamodb:PutItem'],
+        resources: [Fn.sub('arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/agents-table-${environment}', { environment })],
+      }),
+    );
+
+    agentsTable.addToResourcePolicy(
+      new PolicyStatement({
+        sid: 'AllowStateMachineQuery',
+        effect: Effect.ALLOW,
+        principals: [new ArnPrincipal(workflow.stateMachine.role.roleArn)],
+        actions: ['dynamodb:Query'],
+        resources: [Fn.sub('arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/agents-table-${environment}', { environment })],
+      }),
+    );
 
     const scheduledTriggerRule = new Rule(this, 'ScheduledTriggerRule', {
       schedule: Schedule.cron({ hour: '6', minute: '0' }),

--- a/infra/lib/workflow.ts
+++ b/infra/lib/workflow.ts
@@ -106,15 +106,6 @@ export class Workflow extends Construct {
       description: 'Lambda function to initialize session by recording SESSION_INITIATED event',
     });
 
-    sessionInitializerFunction.addToRolePolicy(
-      new PolicyStatement({
-        sid: 'DynamoDBSessionInitializerAccess',
-        effect: Effect.ALLOW,
-        actions: ['dynamodb:PutItem'],
-        resources: [props.journalTable.tableArn],
-      }),
-    );
-
     return sessionInitializerFunction;
   }
 
@@ -229,15 +220,6 @@ export class Workflow extends Construct {
 
     this.sessionInitializerFunction.grantInvoke(stateMachine);
     props.agentInvokerFunction.grantInvoke(stateMachine);
-
-    stateMachine.addToRolePolicy(
-      new PolicyStatement({
-        sid: 'DynamoDBStateMachineAccess',
-        effect: Effect.ALLOW,
-        actions: ['dynamodb:Query'],
-        resources: [props.journalTable.tableArn],
-      }),
-    );
 
     return stateMachine;
   }

--- a/infra/lib/workflow.ts
+++ b/infra/lib/workflow.ts
@@ -108,6 +108,7 @@ export class Workflow extends Construct {
 
     sessionInitializerFunction.addToRolePolicy(
       new PolicyStatement({
+        sid: 'DynamoDBSessionInitializerAccess',
         effect: Effect.ALLOW,
         actions: ['dynamodb:PutItem'],
         resources: [props.journalTable.tableArn],

--- a/infra/lib/workflow.ts
+++ b/infra/lib/workflow.ts
@@ -3,7 +3,6 @@ import { NagSuppressions } from 'cdk-nag';
 import { Construct } from 'constructs';
 
 import { Table } from 'aws-cdk-lib/aws-dynamodb';
-import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Code, Function, LayerVersion, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Choice, Condition, DefinitionBody, Fail, JsonPath, StateMachine, Succeed, Wait, WaitTime } from 'aws-cdk-lib/aws-stepfunctions';


### PR DESCRIPTION
**Issue number:** closes #<replace with issue number>

## Summary
Replace CDK grant methods with specific IAM policies.
### Changes

DynamoDB:
- Agent Runtime: dynamodb:PutItem only 
- Agent Invoker Lambda: dynamodb:PutItem only 
- Session Initializer Lambda: dynamodb:PutItem only 
- State Machine: dynamodb:Query only 

S3 (Agent Runtime only):
- s3:GetObject, s3:PutObject

## Test
- Unit tests
- Manual workflow trigger
- Screenshot
<img width="1396" height="634" alt="Screenshot 2025-11-27 at 11 23 49" src="https://github.com/user-attachments/assets/ee74662a-8e63-446e-b5d4-35ab4fd0cc70" />
<img width="1395" height="503" alt="Screenshot 2025-11-27 at 11 24 04" src="https://github.com/user-attachments/assets/52cc8bc9-074c-4e89-93ce-8a6b85b734ef" />


### User experience

> Please share what the user experience looks like before and after this change

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-samples/sample-agentic-cost-optimizer/blob/main/CONTRIBUTING.md
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Add a PR title that follows the conventional commit semantics - http://conventionalcommits.org
- If relevant, add tests that prove that the change is effective and works
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.