### PR TITLE
fix: remove namespace condition from CloudWatchMetricsAccess

### DIFF
--- a/infra/lib/agent.ts
+++ b/infra/lib/agent.ts
@@ -108,8 +108,8 @@ export class Agent extends Construct {
             sid: 'CloudWatchLogsAccess',
             effect: Effect.ALLOW,
             actions: ['logs:StartQuery', 'logs:GetLogEvents', 'logs:GetLogRecord', 'logs:FilterLogEvents'],
-            // Scoped to Lambda log groups. To control which CloudWatch Logs the agent can access,
-            // modify the resource pattern below (e.g., restrict to specific function names or log group patterns)
+            // Scoped to Lambda log groups to control which CloudWatch Logs the agent can access.
+            // Modify the resource pattern below (e.g., restrict to specific function names or log group patterns)
             resources: [`arn:${stack.partition}:logs:*:*:log-group:/aws/lambda/*`],
           }),
           new PolicyStatement({

--- a/infra/lib/agent.ts
+++ b/infra/lib/agent.ts
@@ -97,11 +97,6 @@ export class Agent extends Construct {
             effect: Effect.ALLOW,
             actions: ['cloudwatch:GetMetricStatistics', 'cloudwatch:ListMetrics'],
             resources: ['*'],
-            conditions: {
-              StringEquals: {
-                'cloudwatch:namespace': 'AWS/Lambda',
-              },
-            },
           }),
           new PolicyStatement({
             sid: 'CloudWatchLogsQueryAccess',

--- a/infra/test/agent-iam-policies.spec.ts
+++ b/infra/test/agent-iam-policies.spec.ts
@@ -11,7 +11,7 @@ describe('Agent IAM Policies', () => {
   const template = Template.fromStack(stack);
 
   describe('CloudWatch Metrics Policy', () => {
-    it('should allow CloudWatch Metrics access scoped to Lambda namespace', () => {
+    it('should allow CloudWatch Metrics read access', () => {
       const policies = template.findResources('AWS::IAM::Policy', {
         Properties: {
           PolicyName: 'MonitoringPolicy',
@@ -29,11 +29,6 @@ describe('Agent IAM Policies', () => {
       expect(metricsStatement.Action).toContain('cloudwatch:GetMetricStatistics');
       expect(metricsStatement.Action).toContain('cloudwatch:ListMetrics');
       expect(metricsStatement.Resource).toEqual('*');
-
-      // Validate namespace condition
-      expect(metricsStatement.Condition).toBeDefined();
-      expect(metricsStatement.Condition.StringEquals).toBeDefined();
-      expect(metricsStatement.Condition.StringEquals['cloudwatch:namespace']).toBe('AWS/Lambda');
     });
   });
 


### PR DESCRIPTION
**Issue number:** closes #<replace with issue number>

## Summary

### Changes

> Please provide a summary of what's being changed

Removed namespace condition from `CloudWatchMetricsAccess` as its [documented](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/iam-cw-condition-keys-namespace.html) only for `PutMetricData` 

### User experience

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.