### PR TITLE
feat: update local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,13 @@
 .venv/
 __pycache__/
 *.pyc
+.coverage
 
 # Node/CDK
 infra/node_modules/
 infra/dist/
 infra/cdk.out/
+infra/coverage
 
 # Local Config
 .idea

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 export UV_PROJECT_ENVIRONMENT := .venv
 
-.PHONY: help setup init pre-commit-install check test run cdk-bootstrap cdk-deploy cdk-hotswap cdk-watch cdk-destroy clean
+.PHONY: help setup init pre-commit-install check test run-agent-local invoke-agent-local cdk-bootstrap cdk-deploy cdk-hotswap cdk-watch cdk-destroy trigger-workflow clean
 
 help:
 	@echo "Development Workflow:"
@@ -12,9 +12,9 @@ help:
 	@echo "  make check        - Run all code quality checks (pre-commit)"
 	@echo "  make test         - Run all tests"
 	@echo ""
-	@echo "Development:"
-	@echo "  make run          - Run the sample local agent"
-	@echo "  make trigger-workflow - Trigger Step Function workflow via EventBridge"
+	@echo "Local Development:"
+	@echo "  make run-agent-local   - Run agent locally with reload"
+	@echo "  make invoke-agent-local - Invoke local agent (run in separate terminal)"
 	@echo ""
 	@echo "AWS Deployment:"
 	@echo "  make cdk-bootstrap - Bootstrap CDK (run once per AWS account/region)"
@@ -22,6 +22,7 @@ help:
 	@echo "  make cdk-hotswap  - Fast deploy Lambda changes only"
 	@echo "  make cdk-watch    - Watch for changes and auto-deploy"
 	@echo "  make cdk-destroy  - Destroy CDK stack from AWS"
+	@echo "  make trigger-workflow - Trigger Step Function workflow via EventBridge"
 	@echo ""
 	@echo "Maintenance:"
 	@echo "  make clean        - Remove venv and build artifacts"
@@ -49,8 +50,15 @@ test:
 	cd infra && npm test
 	@echo "✓ All tests completed!"
 
-run:
-	PYTHONPATH=src uv run python -m agents.main
+run-agent-local:
+	./scripts/run-agent-locally.sh
+
+invoke-agent-local:
+	@echo "Invoking local agent..."
+	@curl -X POST http://localhost:8080/invocations \
+		-H 'Content-Type: application/json' \
+		-H 'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id: local-dev-'$$(uuidgen) \
+		-d '{}'
 
 
 cdk-bootstrap: 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,23 @@ make cdk-hotswap         # Fast AWS Lambda-only updates
 make cdk-watch           # Auto-deploy on file changes
 ```
 
-## Triggering the Agent
+## Local Development
+
+Run the agent locally for testing:
+
+**Terminal 1** - Start the agent:
+```bash
+make run-agent-local
+```
+
+**Terminal 2** - Invoke the agent:
+```bash
+make invoke-agent-local
+```
+
+The agent runs on `http://localhost:8080` with reload. Logs appear in Terminal 1.
+
+## Triggering the Agent (AWS)
 
 **Scheduled**: Runs daily at 6am UTC (configured in EventBridge)
 

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -1537,7 +1537,6 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1697,7 +1696,6 @@
         "mime-types"
       ],
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.242",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
@@ -2072,8 +2070,7 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.4.3.tgz",
       "integrity": "sha512-3+ZB67qWGM1vEstNpj6pGaLNN1qz4gxC1CBhEUhZDZk0PqzQWY65IzC1Doq17MGPa9xa2wJ1G/DJ3swU8kWAHQ==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2328,7 +2325,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2371,7 +2367,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/scripts/run-agent-locally.sh
+++ b/scripts/run-agent-locally.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Local development script for running the agent locally
+# Fetches S3 bucket and DynamoDB table names from CloudFormation outputs
+# Uses your current AWS credentials - the agent will have whatever permissions your credentials have
+
+set -e
+
+# Configuration
+STACK_NAME="${STACK_NAME:-InfraStack}"
+AWS_REGION="${AWS_REGION:-us-east-1}"
+
+echo "Fetching configuration from CloudFormation stack: $STACK_NAME"
+echo "Region: $AWS_REGION"
+echo ""
+
+# Fetch CloudFormation outputs
+STACK_OUTPUTS=$(aws cloudformation describe-stacks \
+  --stack-name "$STACK_NAME" \
+  --region "$AWS_REGION" \
+  --query 'Stacks[0].Outputs' \
+  --output json)
+
+if [ -z "$STACK_OUTPUTS" ] || [ "$STACK_OUTPUTS" == "null" ]; then
+  echo "Error: Could not retrieve stack outputs. Make sure the stack '$STACK_NAME' exists in region '$AWS_REGION'"
+  exit 1
+fi
+
+# Extract values from outputs
+export S3_BUCKET_NAME=$(echo "$STACK_OUTPUTS" | jq -r '.[] | select(.OutputKey=="AgentDataBucketName") | .OutputValue')
+export JOURNAL_TABLE_NAME=$(echo "$STACK_OUTPUTS" | jq -r '.[] | select(.OutputKey=="AgentsTableName") | .OutputValue')
+
+if [ -z "$S3_BUCKET_NAME" ] || [ "$S3_BUCKET_NAME" == "null" ]; then
+  echo "Error: Could not find AgentDataBucketName in stack outputs"
+  exit 1
+fi
+
+if [ -z "$JOURNAL_TABLE_NAME" ] || [ "$JOURNAL_TABLE_NAME" == "null" ]; then
+  echo "Error: Could not find AgentsTableName in stack outputs"
+  exit 1
+fi
+
+# Set environment variables for the agent
+export AWS_REGION="$AWS_REGION"
+export MODEL_ID="${MODEL_ID:-us.anthropic.claude-sonnet-4-5-20250929-v1:0}"
+export TTL_DAYS="${TTL_DAYS:-90}"
+export BYPASS_TOOL_CONSENT="true"
+
+echo "Configuration loaded:"
+echo "  S3 Bucket: $S3_BUCKET_NAME"
+echo "  DynamoDB Table: $JOURNAL_TABLE_NAME"
+echo "  AWS Region: $AWS_REGION"
+echo "  Model ID: $MODEL_ID"
+echo ""
+echo "Starting agent with reload on http://localhost:8080/invocations"
+echo ""
+echo "To test the agent, run this in a new terminal:"
+echo "  curl -X POST http://localhost:8080/invocations \\"
+echo "    -H 'Content-Type: application/json' \\"
+echo "    -H 'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id: local-dev-\$(uuidgen)' \\"
+echo "    -d '{}'"
+echo ""
+
+# Run uvicorn directly with reload
+uv run uvicorn src.agents.main:app --host 0.0.0.0 --port 8080 --reload

--- a/src/agents/main.py
+++ b/src/agents/main.py
@@ -34,8 +34,8 @@ if "BYPASS_TOOL_CONSENT" not in os.environ:
 
 DEFAULT_MAX_ATTEMPTS = 5  # Increased from default 3 for better resilience with Bedrock
 DEFAULT_RETRY_MODE = "standard"  # AWS recommended mode with exponential backoff + jitter
-DEFAULT_CONNECT_TIMEOUT = 60  # Bedrock connection establishment typically completes within 10s
-DEFAULT_READ_TIMEOUT = 120  # Bedrock streaming responses can take 60-90s for complex queries
+DEFAULT_CONNECT_TIMEOUT = 60  # Time allowed for establishing connection to Bedrock
+DEFAULT_READ_TIMEOUT = 600  # Time allowed for streaming responses from model
 DEFAULT_MAX_POOL_CONNECTIONS = 10
 
 


### PR DESCRIPTION
**Issue number:** N/A (enhancement)

## Summary

### Changes

Added local development support for running and testing the agent locally:

- Created `scripts/run-agent-locally.sh` to fetch CloudFormation outputs and start agent with `uvicorn`
- Added `make run-agent-local` and `make invoke-agent-local` targets
- Increased `DEFAULT_READ_TIMEOUT` from 120s to 600s for complex agentic workflows (60+ tool calls)
- Updated README with local development instructions

### User experience

**Before:** Developers had to deploy to AWS and trigger via EventBridge to test agent changes.

**After:** Developers can run the agent locally with reload:
```bash
# Terminal 1
make run-agent-local

# Terminal 2  
make invoke-agent-local
