### PR TITLE
fix: duplicated code and add tests

### DIFF
--- a/infra/lib/agent.ts
+++ b/infra/lib/agent.ts
@@ -12,6 +12,7 @@ export interface AgentProps {
   agentRuntimeName: string;
   description?: string;
   environmentVariables?: { [key: string]: string };
+  modelId: string;
 }
 
 export class Agent extends Construct {
@@ -21,7 +22,7 @@ export class Agent extends Construct {
   constructor(scope: Construct, id: string, props: AgentProps) {
     super(scope, id);
 
-    const { agentRuntimeName, description, environmentVariables = {} } = props;
+    const { agentRuntimeName, description, environmentVariables = {}, modelId } = props;
 
     const environment = this.node.tryGetContext('env') || 'dev';
     const stack = Stack.of(this);
@@ -52,10 +53,6 @@ export class Agent extends Construct {
     });
 
     deploymentPackage.grantRead(this.runtime.role);
-
-    const modelId = InfraConfig.inferenceProfileRegion
-      ? `${InfraConfig.inferenceProfileRegion}.${InfraConfig.modelId}`
-      : InfraConfig.modelId;
 
     const bedrockPolicy = new Policy(this, 'BedrockModelInvocationPolicy', {
       policyName: 'BedrockModelInvocation',

--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -64,6 +64,7 @@ export class InfraStack extends Stack {
     this.agent = new Agent(this, 'AgentCore', {
       agentRuntimeName: `agentRuntime_${environment}_${version}`,
       description: `Agent runtime for ${environment} environment`,
+      modelId,
       environmentVariables: {
         BYPASS_TOOL_CONSENT: 'true',
         S3_BUCKET_NAME: agentDataBucket.bucketName,

--- a/infra/test/agent-iam-policies.spec.ts
+++ b/infra/test/agent-iam-policies.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { createTestStack } from './setup';
+import { createTestStack, getBedrockPolicyStatements } from './setup';
 
 describe('Agent IAM Policies', () => {
   const { template } = createTestStack();
@@ -13,8 +13,7 @@ describe('Agent IAM Policies', () => {
         },
       });
 
-      const policyKey = Object.keys(policies)[0];
-      const policy = policies[policyKey];
+      const policy = Object.values(policies)[0] as any;
       const statements = policy.Properties.PolicyDocument.Statement;
 
       const metricsStatement = statements.find((stmt: any) => stmt.Sid === 'CloudWatchMetricsAccess');
@@ -35,8 +34,7 @@ describe('Agent IAM Policies', () => {
         },
       });
 
-      const policyKey = Object.keys(policies)[0];
-      const policy = policies[policyKey];
+      const policy = Object.values(policies)[0] as any;
       const statements = policy.Properties.PolicyDocument.Statement;
 
       const logsAccessStatement = statements.find((stmt: any) => stmt.Sid === 'CloudWatchLogsAccess');
@@ -59,8 +57,7 @@ describe('Agent IAM Policies', () => {
         },
       });
 
-      const policyKey = Object.keys(policies)[0];
-      const policy = policies[policyKey];
+      const policy = Object.values(policies)[0] as any;
       const statements = policy.Properties.PolicyDocument.Statement;
 
       const queryResultsStatement = statements.find((stmt: any) => stmt.Sid === 'CloudWatchLogsQueryAccess');
@@ -79,8 +76,7 @@ describe('Agent IAM Policies', () => {
         },
       });
 
-      const policyKey = Object.keys(policies)[0];
-      const policy = policies[policyKey];
+      const policy = Object.values(policies)[0] as any;
       const statements = policy.Properties.PolicyDocument.Statement;
 
       const logsStatements = statements.filter(
@@ -103,8 +99,7 @@ describe('Agent IAM Policies', () => {
         },
       });
 
-      const policyKey = Object.keys(policies)[0];
-      const policy = policies[policyKey];
+      const policy = Object.values(policies)[0] as any;
       const statements = policy.Properties.PolicyDocument.Statement;
 
       const lambdaStatement = statements.find((stmt: any) => stmt.Sid === 'LambdaMonitoring');

--- a/infra/test/agent-iam-policies.spec.ts
+++ b/infra/test/agent-iam-policies.spec.ts
@@ -1,14 +1,9 @@
-import { App } from 'aws-cdk-lib';
 import { describe, expect, it } from 'vitest';
 
-import { Template } from 'aws-cdk-lib/assertions';
-
-import { InfraStack } from '../lib/infra-stack';
+import { createTestStack } from './setup';
 
 describe('Agent IAM Policies', () => {
-  const app = new App();
-  const stack = new InfraStack(app, 'TestStack');
-  const template = Template.fromStack(stack);
+  const { template } = createTestStack();
 
   describe('CloudWatch Metrics Policy', () => {
     it('should allow CloudWatch Metrics read access', () => {

--- a/infra/test/agent-iam-policies.spec.ts
+++ b/infra/test/agent-iam-policies.spec.ts
@@ -1,89 +1,61 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
-import { createTestStack, getBedrockPolicyStatements } from './setup';
+import { type PolicyResource, type PolicyStatementJson, createTestStack } from './setup';
 
 describe('Agent IAM Policies', () => {
   const { template } = createTestStack();
+  let monitoringPolicy: PolicyResource;
+  let statements: PolicyStatementJson[];
+
+  beforeEach(() => {
+    const policies = template.findResources('AWS::IAM::Policy', {
+      Properties: { PolicyName: 'MonitoringPolicy' },
+    });
+    monitoringPolicy = Object.values(policies)[0] as PolicyResource;
+    statements = monitoringPolicy.Properties.PolicyDocument.Statement;
+  });
 
   describe('CloudWatch Metrics Policy', () => {
     it('should allow CloudWatch Metrics read access', () => {
-      const policies = template.findResources('AWS::IAM::Policy', {
-        Properties: {
-          PolicyName: 'MonitoringPolicy',
-        },
-      });
-
-      const policy = Object.values(policies)[0] as any;
-      const statements = policy.Properties.PolicyDocument.Statement;
-
-      const metricsStatement = statements.find((stmt: any) => stmt.Sid === 'CloudWatchMetricsAccess');
+      const metricsStatement = statements.find((stmt) => stmt.Sid === 'CloudWatchMetricsAccess');
 
       expect(metricsStatement).toBeDefined();
-      expect(metricsStatement.Effect).toBe('Allow');
-      expect(metricsStatement.Action).toContain('cloudwatch:GetMetricStatistics');
-      expect(metricsStatement.Action).toContain('cloudwatch:ListMetrics');
-      expect(metricsStatement.Resource).toEqual('*');
+      expect(metricsStatement!.Effect).toBe('Allow');
+      expect(metricsStatement!.Action).toContain('cloudwatch:GetMetricStatistics');
+      expect(metricsStatement!.Action).toContain('cloudwatch:ListMetrics');
+      expect(metricsStatement!.Resource).toEqual('*');
     });
   });
 
   describe('CloudWatch Logs Monitoring Policy', () => {
     it('should scope log access actions to Lambda log groups', () => {
-      const policies = template.findResources('AWS::IAM::Policy', {
-        Properties: {
-          PolicyName: 'MonitoringPolicy',
-        },
-      });
-
-      const policy = Object.values(policies)[0] as any;
-      const statements = policy.Properties.PolicyDocument.Statement;
-
-      const logsAccessStatement = statements.find((stmt: any) => stmt.Sid === 'CloudWatchLogsAccess');
+      const logsAccessStatement = statements.find((stmt) => stmt.Sid === 'CloudWatchLogsAccess');
 
       expect(logsAccessStatement).toBeDefined();
-      expect(logsAccessStatement.Effect).toBe('Allow');
-      expect(logsAccessStatement.Action).toContain('logs:StartQuery');
-      expect(logsAccessStatement.Action).toContain('logs:GetLogEvents');
-      expect(logsAccessStatement.Action).toContain('logs:FilterLogEvents');
+      expect(logsAccessStatement!.Effect).toBe('Allow');
+      expect(logsAccessStatement!.Action).toContain('logs:StartQuery');
+      expect(logsAccessStatement!.Action).toContain('logs:GetLogEvents');
+      expect(logsAccessStatement!.Action).toContain('logs:FilterLogEvents');
 
-      const resource = logsAccessStatement.Resource;
+      const resource = logsAccessStatement!.Resource;
       const resourceString = JSON.stringify(resource);
       expect(resourceString).toContain('logs:*:*:log-group:/aws/lambda/*');
     });
 
     it('should allow StopQuery and GetQueryResults with wildcard resources', () => {
-      const policies = template.findResources('AWS::IAM::Policy', {
-        Properties: {
-          PolicyName: 'MonitoringPolicy',
-        },
-      });
-
-      const policy = Object.values(policies)[0] as any;
-      const statements = policy.Properties.PolicyDocument.Statement;
-
-      const queryResultsStatement = statements.find((stmt: any) => stmt.Sid === 'CloudWatchLogsQueryAccess');
+      const queryResultsStatement = statements.find((stmt) => stmt.Sid === 'CloudWatchLogsQueryAccess');
 
       expect(queryResultsStatement).toBeDefined();
-      expect(queryResultsStatement.Effect).toBe('Allow');
-      expect(queryResultsStatement.Action).toContain('logs:StopQuery');
-      expect(queryResultsStatement.Action).toContain('logs:GetQueryResults');
-      expect(queryResultsStatement.Resource).toEqual('*');
+      expect(queryResultsStatement!.Effect).toBe('Allow');
+      expect(queryResultsStatement!.Action).toContain('logs:StopQuery');
+      expect(queryResultsStatement!.Action).toContain('logs:GetQueryResults');
+      expect(queryResultsStatement!.Resource).toEqual('*');
     });
 
     it('should not include CloudWatch Metrics actions in Logs statements', () => {
-      const policies = template.findResources('AWS::IAM::Policy', {
-        Properties: {
-          PolicyName: 'MonitoringPolicy',
-        },
-      });
+      const logsStatements = statements.filter((stmt) => stmt.Sid === 'CloudWatchLogsAccess' || stmt.Sid === 'CloudWatchLogsQueryAccess');
 
-      const policy = Object.values(policies)[0] as any;
-      const statements = policy.Properties.PolicyDocument.Statement;
-
-      const logsStatements = statements.filter(
-        (stmt: any) => stmt.Sid === 'CloudWatchLogsAccess' || stmt.Sid === 'CloudWatchLogsQueryAccess',
-      );
-
-      logsStatements.forEach((stmt: any) => {
+      logsStatements.forEach((stmt) => {
         const actions = Array.isArray(stmt.Action) ? stmt.Action : [stmt.Action];
         expect(actions).not.toContain('cloudwatch:GetMetricStatistics');
         expect(actions).not.toContain('cloudwatch:ListMetrics');
@@ -93,21 +65,12 @@ describe('Agent IAM Policies', () => {
 
   describe('Lambda Monitoring Policy', () => {
     it('should allow Lambda read-only monitoring actions', () => {
-      const policies = template.findResources('AWS::IAM::Policy', {
-        Properties: {
-          PolicyName: 'MonitoringPolicy',
-        },
-      });
-
-      const policy = Object.values(policies)[0] as any;
-      const statements = policy.Properties.PolicyDocument.Statement;
-
-      const lambdaStatement = statements.find((stmt: any) => stmt.Sid === 'LambdaMonitoring');
+      const lambdaStatement = statements.find((stmt) => stmt.Sid === 'LambdaMonitoring');
 
       expect(lambdaStatement).toBeDefined();
-      expect(lambdaStatement.Effect).toBe('Allow');
-      expect(lambdaStatement.Action).toContain('lambda:GetFunction');
-      expect(lambdaStatement.Action).toContain('lambda:ListFunctions');
+      expect(lambdaStatement!.Effect).toBe('Allow');
+      expect(lambdaStatement!.Action).toContain('lambda:GetFunction');
+      expect(lambdaStatement!.Action).toContain('lambda:ListFunctions');
     });
   });
 });

--- a/infra/test/eventbridge-rules.spec.ts
+++ b/infra/test/eventbridge-rules.spec.ts
@@ -1,14 +1,9 @@
-import { App } from 'aws-cdk-lib';
 import { describe, expect, it } from 'vitest';
 
-import { Template } from 'aws-cdk-lib/assertions';
-
-import { InfraStack } from '../lib/infra-stack';
+import { createTestStack } from './setup';
 
 describe('EventBridge Rules', () => {
-  const app = new App();
-  const stack = new InfraStack(app, 'TestStack');
-  const template = Template.fromStack(stack);
+  const { template } = createTestStack();
 
   describe('Manual Trigger Rule', () => {
     it('should be configured with correct event pattern', () => {

--- a/infra/test/eventbridge-rules.spec.ts
+++ b/infra/test/eventbridge-rules.spec.ts
@@ -1,22 +1,31 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { createTestStack } from './setup';
+
+interface EventBridgeRule {
+  Properties: {
+    EventPattern?: {
+      source: string[];
+      'detail-type'?: string[];
+    };
+    ScheduleExpression?: string;
+    Description: string;
+    Targets: Array<{
+      InputTransformer?: {
+        InputPathsMap: Record<string, string>;
+        InputTemplate: string;
+      };
+    }>;
+  };
+}
 
 describe('EventBridge Rules', () => {
   const { template } = createTestStack();
 
   describe('Manual Trigger Rule', () => {
-    it('should be configured with correct event pattern', () => {
-      template.hasResourceProperties('AWS::Events::Rule', {
-        EventPattern: {
-          source: ['manual-trigger'],
-          'detail-type': ['execute-agent'],
-        },
-        Description: 'Rule to trigger agent workflow via manual EventBridge events',
-      });
-    });
+    let manualRule: EventBridgeRule;
 
-    it('should have a target configured', () => {
+    beforeEach(() => {
       const rules = template.findResources('AWS::Events::Rule', {
         Properties: {
           EventPattern: {
@@ -24,50 +33,52 @@ describe('EventBridge Rules', () => {
           },
         },
       });
+      manualRule = Object.values(rules)[0] as EventBridgeRule;
+    });
 
-      const ruleKey = Object.keys(rules)[0];
-      const rule = rules[ruleKey];
-      expect(rule.Properties.Targets).toBeDefined();
-      expect(rule.Properties.Targets).toHaveLength(1);
+    it('should be configured with correct event pattern', () => {
+      expect(manualRule.Properties.EventPattern).toEqual({
+        source: ['manual-trigger'],
+        'detail-type': ['execute-agent'],
+      });
+      expect(manualRule.Properties.Description).toBe('Rule to trigger agent workflow via manual EventBridge events');
+    });
+
+    it('should have a target configured', () => {
+      expect(manualRule.Properties.Targets).toBeDefined();
+      expect(manualRule.Properties.Targets).toHaveLength(1);
     });
   });
 
   describe('Scheduled Trigger Rule', () => {
-    it('should be configured to run daily at 6am UTC', () => {
-      template.hasResourceProperties('AWS::Events::Rule', {
-        ScheduleExpression: 'cron(0 6 * * ? *)',
-        Description: 'Rule to trigger agent workflow daily at 6am UTC',
+    let scheduledRule: EventBridgeRule;
+
+    beforeEach(() => {
+      const rules = template.findResources('AWS::Events::Rule', {
+        Properties: {
+          ScheduleExpression: 'cron(0 6 * * ? *)',
+        },
       });
+      scheduledRule = Object.values(rules)[0] as EventBridgeRule;
+    });
+
+    it('should be configured to run daily at 6am UTC', () => {
+      expect(scheduledRule.Properties.ScheduleExpression).toBe('cron(0 6 * * ? *)');
+      expect(scheduledRule.Properties.Description).toBe('Rule to trigger agent workflow daily at 6am UTC');
     });
 
     it('should have a target configured', () => {
-      const rules = template.findResources('AWS::Events::Rule', {
-        Properties: {
-          ScheduleExpression: 'cron(0 6 * * ? *)',
-        },
-      });
-
-      const ruleKey = Object.keys(rules)[0];
-      const rule = rules[ruleKey];
-      expect(rule.Properties.Targets).toBeDefined();
-      expect(rule.Properties.Targets).toHaveLength(1);
+      expect(scheduledRule.Properties.Targets).toBeDefined();
+      expect(scheduledRule.Properties.Targets).toHaveLength(1);
     });
 
     it('should use event-id for session_id to meet AgentCore 33+ character requirement', () => {
-      const rules = template.findResources('AWS::Events::Rule', {
-        Properties: {
-          ScheduleExpression: 'cron(0 6 * * ? *)',
-        },
-      });
-
-      const ruleKey = Object.keys(rules)[0];
-      const rule = rules[ruleKey];
-      const target = rule.Properties.Targets[0];
+      const target = scheduledRule.Properties.Targets[0];
 
       expect(target.InputTransformer).toBeDefined();
-      expect(target.InputTransformer.InputPathsMap).toHaveProperty('id');
-      expect(target.InputTransformer.InputPathsMap.id).toBe('$.id');
-      expect(target.InputTransformer.InputTemplate).toContain('"session_id":<id>');
+      expect(target.InputTransformer!.InputPathsMap).toHaveProperty('id');
+      expect(target.InputTransformer!.InputPathsMap.id).toBe('$.id');
+      expect(target.InputTransformer!.InputTemplate).toContain('"session_id":<id>');
     });
   });
 

--- a/infra/test/model-id-construction.spec.ts
+++ b/infra/test/model-id-construction.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { createTestStack } from './setup';
+
+describe('Model ID Construction Logic', () => {
+  const { template } = createTestStack();
+
+  it('should construct modelId with region prefix when inferenceProfileRegion is set', () => {
+    const policies = template.findResources('AWS::IAM::Policy', {
+      Properties: {
+        PolicyName: 'BedrockModelInvocation',
+      },
+    });
+
+    const policyKey = Object.keys(policies)[0];
+    const policy = policies[policyKey];
+    const statements = policy.Properties.PolicyDocument.Statement;
+    const invokeStatement = statements.find((stmt: any) => stmt.Sid === 'InvokeBedrockModel');
+
+    const inferenceProfileResource = invokeStatement.Resource.find((r: any) => {
+      if (r['Fn::Join']) {
+        const parts = r['Fn::Join'][1];
+        return parts.some((p: any) => typeof p === 'string' && p.includes(':inference-profile/'));
+      }
+      return false;
+    });
+
+    const parts = inferenceProfileResource['Fn::Join'][1];
+    const modelIdPart = parts.find((p: any) => typeof p === 'string' && p.includes(':inference-profile/'));
+    const actualModelId = modelIdPart.split(':inference-profile/')[1];
+
+    expect(actualModelId).toBe('us.anthropic.claude-sonnet-4-20250514-v1:0');
+    expect(actualModelId).not.toBe('eu.anthropic.claude-sonnet-4-20250514-v1:0');
+  });
+
+  it('should use base modelId without prefix in foundation model ARN', () => {
+    const policies = template.findResources('AWS::IAM::Policy', {
+      Properties: {
+        PolicyName: 'BedrockModelInvocation',
+      },
+    });
+
+    const policyKey = Object.keys(policies)[0];
+    const policy = policies[policyKey];
+    const statements = policy.Properties.PolicyDocument.Statement;
+    const invokeStatement = statements.find((stmt: any) => stmt.Sid === 'InvokeBedrockModel');
+
+    const foundationModelResource = invokeStatement.Resource.find((r: any) => {
+      if (r['Fn::Join']) {
+        const parts = r['Fn::Join'][1];
+        return parts.some((p: any) => typeof p === 'string' && p.includes(':foundation-model/'));
+      }
+      return false;
+    });
+
+    const parts = foundationModelResource['Fn::Join'][1];
+    const modelIdPart = parts.find((p: any) => typeof p === 'string' && p.includes(':foundation-model/'));
+    const foundationModelId = modelIdPart.split(':foundation-model/')[1];
+
+    expect(foundationModelId).toBe('anthropic.claude-sonnet-4-20250514-v1:0');
+    expect(foundationModelId).not.toContain('us.');
+  });
+});

--- a/infra/test/model-id-construction.spec.ts
+++ b/infra/test/model-id-construction.spec.ts
@@ -1,44 +1,44 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
-import { createTestStack, getBedrockPolicyStatements } from './setup';
+import { type CfnJoin, type PolicyResource, type PolicyStatementJson, createTestStack } from './setup';
 
 describe('Model ID Construction Logic', () => {
   const { template } = createTestStack();
+  let invokeStatement: PolicyStatementJson;
 
-  it('should construct modelId with region prefix when inferenceProfileRegion is set', () => {
-    const statements = getBedrockPolicyStatements(template);
-    const invokeStatement = statements.find((stmt: any) => stmt.Sid === 'InvokeBedrockModel');
+  beforeEach(() => {
+    const policies = template.findResources('AWS::IAM::Policy', {
+      Properties: { PolicyName: 'BedrockModelInvocation' },
+    });
+    const policy = Object.values(policies)[0] as PolicyResource;
+    const statements = policy.Properties.PolicyDocument.Statement;
+    invokeStatement = statements.find((stmt) => stmt.Sid === 'InvokeBedrockModel')!;
+  });
 
-    const inferenceProfileResource = invokeStatement.Resource.find((r: any) => {
-      if (r['Fn::Join']) {
-        const parts = r['Fn::Join'][1];
-        return parts.some((p: any) => typeof p === 'string' && p.includes(':inference-profile/'));
+  const extractModelId = (resources: unknown, pattern: string): string => {
+    const resourceArray = resources as unknown[];
+    const resource = resourceArray.find((r) => {
+      const cfnResource = r as Partial<CfnJoin>;
+      if (cfnResource['Fn::Join']) {
+        const parts = cfnResource['Fn::Join'][1];
+        return parts.some((p) => typeof p === 'string' && p.includes(pattern));
       }
       return false;
-    });
+    }) as CfnJoin;
 
-    const parts = inferenceProfileResource['Fn::Join'][1];
-    const modelIdPart = parts.find((p: any) => typeof p === 'string' && p.includes(':inference-profile/'));
-    const actualModelId = modelIdPart.split(':inference-profile/')[1];
+    const parts = resource['Fn::Join'][1];
+    const modelIdPart = parts.find((p) => typeof p === 'string' && p.includes(pattern)) as string;
+    return modelIdPart.split(pattern)[1];
+  };
+
+  it('should construct modelId with region prefix when inferenceProfileRegion is set', () => {
+    const actualModelId = extractModelId(invokeStatement.Resource, ':inference-profile/');
 
     expect(actualModelId).toBe('us.anthropic.claude-sonnet-4-20250514-v1:0');
   });
 
   it('should use base modelId without prefix in foundation model ARN', () => {
-    const statements = getBedrockPolicyStatements(template);
-    const invokeStatement = statements.find((stmt: any) => stmt.Sid === 'InvokeBedrockModel');
-
-    const foundationModelResource = invokeStatement.Resource.find((r: any) => {
-      if (r['Fn::Join']) {
-        const parts = r['Fn::Join'][1];
-        return parts.some((p: any) => typeof p === 'string' && p.includes(':foundation-model/'));
-      }
-      return false;
-    });
-
-    const parts = foundationModelResource['Fn::Join'][1];
-    const modelIdPart = parts.find((p: any) => typeof p === 'string' && p.includes(':foundation-model/'));
-    const foundationModelId = modelIdPart.split(':foundation-model/')[1];
+    const foundationModelId = extractModelId(invokeStatement.Resource, ':foundation-model/');
 
     expect(foundationModelId).toBe('anthropic.claude-sonnet-4-20250514-v1:0');
     expect(foundationModelId).not.toContain('us.');

--- a/infra/test/model-id-construction.spec.ts
+++ b/infra/test/model-id-construction.spec.ts
@@ -1,20 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { createTestStack } from './setup';
+import { createTestStack, getBedrockPolicyStatements } from './setup';
 
 describe('Model ID Construction Logic', () => {
   const { template } = createTestStack();
 
   it('should construct modelId with region prefix when inferenceProfileRegion is set', () => {
-    const policies = template.findResources('AWS::IAM::Policy', {
-      Properties: {
-        PolicyName: 'BedrockModelInvocation',
-      },
-    });
-
-    const policyKey = Object.keys(policies)[0];
-    const policy = policies[policyKey];
-    const statements = policy.Properties.PolicyDocument.Statement;
+    const statements = getBedrockPolicyStatements(template);
     const invokeStatement = statements.find((stmt: any) => stmt.Sid === 'InvokeBedrockModel');
 
     const inferenceProfileResource = invokeStatement.Resource.find((r: any) => {
@@ -34,15 +26,7 @@ describe('Model ID Construction Logic', () => {
   });
 
   it('should use base modelId without prefix in foundation model ARN', () => {
-    const policies = template.findResources('AWS::IAM::Policy', {
-      Properties: {
-        PolicyName: 'BedrockModelInvocation',
-      },
-    });
-
-    const policyKey = Object.keys(policies)[0];
-    const policy = policies[policyKey];
-    const statements = policy.Properties.PolicyDocument.Statement;
+    const statements = getBedrockPolicyStatements(template);
     const invokeStatement = statements.find((stmt: any) => stmt.Sid === 'InvokeBedrockModel');
 
     const foundationModelResource = invokeStatement.Resource.find((r: any) => {

--- a/infra/test/model-id-construction.spec.ts
+++ b/infra/test/model-id-construction.spec.ts
@@ -22,7 +22,6 @@ describe('Model ID Construction Logic', () => {
     const actualModelId = modelIdPart.split(':inference-profile/')[1];
 
     expect(actualModelId).toBe('us.anthropic.claude-sonnet-4-20250514-v1:0');
-    expect(actualModelId).not.toBe('eu.anthropic.claude-sonnet-4-20250514-v1:0');
   });
 
   it('should use base modelId without prefix in foundation model ARN', () => {

--- a/infra/test/setup.ts
+++ b/infra/test/setup.ts
@@ -1,8 +1,23 @@
 import { App } from 'aws-cdk-lib';
 
 import { Template } from 'aws-cdk-lib/assertions';
+import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
 
 import { InfraStack } from '../lib/infra-stack';
+
+export type PolicyStatementJson = ReturnType<PolicyStatement['toJSON']>;
+
+export interface PolicyResource {
+  Properties: {
+    PolicyDocument: {
+      Statement: PolicyStatementJson[];
+    };
+  };
+}
+
+export interface CfnJoin {
+  'Fn::Join': [string, unknown[]];
+}
 
 /**
  * Creates a test stack and template for testing
@@ -13,17 +28,4 @@ export function createTestStack() {
   const template = Template.fromStack(stack);
 
   return { app, stack, template };
-}
-
-/**
- * Gets the Bedrock IAM policy statements from a template
- */
-export function getBedrockPolicyStatements(template: Template) {
-  const policies = template.findResources('AWS::IAM::Policy', {
-    Properties: {
-      PolicyName: 'BedrockModelInvocation',
-    },
-  });
-  const policy = Object.values(policies)[0] as any;
-  return policy.Properties.PolicyDocument.Statement;
 }

--- a/infra/test/setup.ts
+++ b/infra/test/setup.ts
@@ -1,0 +1,16 @@
+import { App } from 'aws-cdk-lib';
+
+import { Template } from 'aws-cdk-lib/assertions';
+
+import { InfraStack } from '../lib/infra-stack';
+
+/**
+ * Creates a test stack and template for testing
+ */
+export function createTestStack() {
+  const app = new App();
+  const stack = new InfraStack(app, 'TestStack');
+  const template = Template.fromStack(stack);
+
+  return { app, stack, template };
+}

--- a/infra/test/setup.ts
+++ b/infra/test/setup.ts
@@ -14,3 +14,16 @@ export function createTestStack() {
 
   return { app, stack, template };
 }
+
+/**
+ * Gets the Bedrock IAM policy statements from a template
+ */
+export function getBedrockPolicyStatements(template: Template) {
+  const policies = template.findResources('AWS::IAM::Policy', {
+    Properties: {
+      PolicyName: 'BedrockModelInvocation',
+    },
+  });
+  const policy = Object.values(policies)[0] as any;
+  return policy.Properties.PolicyDocument.Statement;
+}


### PR DESCRIPTION
**Issue number:** closes #<issue_number>

## Summary

### Changes

Refactored model ID construction logic to eliminate code duplication between `infra-stack.ts` and `agent.ts`:

- **Removed duplicate logic**: Model ID construction (adding inference profile region prefix) now only exists in `infra-stack.ts` instead of being duplicated in both files
- **Updated Agent construct**: Added `modelId` as a required parameter to `AgentProps` interface, which is now passed from the parent stack
- **Added tests**: Created 2 tests in `model-id-construction.spec.ts` that verify the ternary operator logic 
- **Created reusable test setup**: Extracted common test setup code into `infra/test/setup.ts`

### User experience

**Before:**
- Model ID construction logic was duplicated in two places, making it harder to maintain
- Test files had repetitive boilerplate code for creating test stacks

**After:**
- Cleaner, more maintainable code
- Reusable test setup makes tests easier to write
---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
