### PR TITLE
refactor: docs

### DIFF
--- a/docs/agentcore_logging_investigation.md
+++ b/docs/agentcore_logging_investigation.md
@@ -14,53 +14,54 @@ When we invoked the agent, we observed too many log streams being created in Clo
 
 **Discovery**: The number of log streams depends on the deployment method:
 
-**Agent-as-Container Deployment** (Docker image):
-- Creates **~11 log streams** (10 runtime + 1 OTEL)
-- AgentCore pre-warms **10 containers** for performance and scalability
-- Each container gets its own log stream: `/aws/bedrock-agentcore/runtimes/<agent_id>-<endpoint_name>/runtime-logs-<UUID>`
-- Plus 1 OTEL stream: `/aws/bedrock-agentcore/runtimes/<agent_id>-<endpoint_name>/otel-rt-logs`
+**Agent-as-Container Deployment** - Docker image:
+- Creates ~11 log streams at deployment: 10 runtime + 1 OTEL
+- AgentCore pre-warms 10 containers for performance and scalability
+- Runtime log format: `YYYY/MM/DD/[runtime-logs-{SESSION_ID}]{EXECUTION_ENVIRONMENT_UUID}`
+- OTEL log format: `otel-rt-logs`
 
-**Agent-as-Code Deployment** (Python code via S3):
-- Creates **only 2 log streams** (1 runtime + 1 OTEL)
-- Single runtime stream: `/aws/bedrock-agentcore/runtimes/<agent_id>-<endpoint_name>/runtime-logs-<UUID>`
-- Single OTEL stream: `/aws/bedrock-agentcore/runtimes/<agent_id>-<endpoint_name>/otel-rt-logs`
+**Agent-as-Code Deployment** - Python code via S3:
+- Creates 1 OTEL stream at deployment: `otel-rt-logs`
+- Runtime streams created on-demand after first invocation
+- Runtime log format: `YYYY/MM/DD/[runtime-logs-{SESSION_ID}]{EXECUTION_ENVIRONMENT_UUID}`
+  - Example: `2025/12/02/[runtime-logs-f07e0b11-3090-d01d-78b7-ad8eaf4a93fd]d46c08d5-f8a1-4bb0-9b8f-c2d9519a7a95`
+  - Created per execution environment, not per session
+  - Same session ID can appear in multiple log streams with different execution environment UUIDs
 
 **Current Implementation**:
 Agent-as-code deployment using `AgentRuntimeArtifact.fromS3()` in `infra/lib/agent.ts`.
 
 **Why This Matters**:
-- **Agent-as-code** = cleaner CloudWatch logs (only 2 streams)
-- **Agent-as-container** = more log streams but better cold start performance (pre-warmed containers)
-- The UUID in log stream names represents container instances, not session IDs
-- Session IDs are tracked separately via `context.session_id` in the agent code
+- Agent-as-code: 1 OTEL stream at deployment + runtime streams created on-demand per execution environment
+- Agent-as-container: 1 OTEL stream + 10 pre-warmed runtime streams - better cold start performance
+- Execution environment behavior similar to AWS Lambda:
+  - Runtime log streams created per execution environment, not per session
+  - Same session ID can be routed to different execution environments
+  - Concurrent requests for same session can use different environments
+  - Global state is not reliable - use external storage like DynamoDB for journaling and S3 for data passing
 
 **Log Stream Types**:
-- **runtime-logs-<UUID>**: Standard logs (stdout/stderr) from agent execution
-- **otel-rt-logs**: OTEL structured logs with telemetry data
-- **Traces and spans**: `/aws/spans/default` (separate log group)
+- Runtime logs: Standard logs with stdout/stderr from agent execution
+- OTEL logs: Structured logs with telemetry data
+- Traces and spans: Stored in `/aws/spans/default` log group
 
 ### False Assumptions We Made
 
-1. **Multiple streams = Multiple executions** ❌
-   - **Reality**: Deployment creates 11 streams regardless of execution count
-   - **Impact**: Led to confusion about logging volume and behavior
+1. Multiple streams = Multiple executions
+   - Reality: Agent-as-container creates 11 streams at deployment; agent-as-code creates 1 OTEL stream at deployment + runtime streams on-demand
+   - Impact: Led to confusion about logging volume and behavior
 
-2. **Complex logging setup needed** ❌
-   - **Reality**: AgentCore handles logging automatically
-   - **Impact**: Over-engineered logging solutions
-
-3. **Manual status tracking required** ❌
-   - **Reality**: `@app.async_task` decorator handles status automatically
-   - **Impact**: Unnecessary complexity with manual ping handlers
+2. Manual status tracking required
+   - Reality: `@app.async_task` decorator handles status automatically
+   - Impact: Unnecessary complexity with manual ping handlers
 
 ## What We Tried
 
 ### 1. Complex Multi-Logger Setup
 - Tried mixing multiple loggers (Strands, AgentCore, custom handlers)
-- Over-complicated and confusing
 
 ### 2. Manual Status Tracking
-- Custom `@app.ping` handler caused recursion errors
+- Custom `@app.ping` handler
 - Unnecessary complexity
 
 ### 3. Manual Async Task Management
@@ -87,29 +88,27 @@ Agent-as-code deployment using `AgentRuntimeArtifact.fromS3()` in `infra/lib/age
 ## Key Learnings
 
 ### AgentCore Logging Behavior
-- **Runtime logs**: Basic lifecycle events (agent startup, invocation)
-- **otel-rt-logs**: Continuous telemetry stream with structured JSON
-- **Automatic status logging**: AgentCore logs status changes internally
-- **Log stream count depends on deployment method**:
-  - Agent-as-container: ~11 streams (10 pre-warmed containers + 1 OTEL)
-  - Agent-as-code: 2 streams (1 runtime + 1 OTEL) ← **Our implementation**
+- Runtime logs: Basic lifecycle events like agent startup and invocation - created per execution environment after first invocation
+- OTEL logs: Continuous telemetry stream with structured JSON - created at deployment
+- Automatic status logging: AgentCore logs status changes internally
+- Log stream count depends on deployment method:
+  - Agent-as-container: ~11 streams at deployment - 10 pre-warmed runtime + 1 OTEL
+  - Agent-as-code: 1 OTEL stream at deployment + runtime streams created on-demand per execution environment
 
 ### What We Learned
-1. **AgentCore's built-in logger works** - Simple and integrates with AgentCore streams
-2. **@app.async_task decorator is the recommended approach** - Handles status automatically without manual `add_async_task()` and `complete_async_task()` calls
-3. **External loggers didn't create extra streams** - Powertools and other logging mechanisms didn't contribute to the 11+ stream issue
-4. **Native async is cleaner** - Strands has `invoke_async()`, no ThreadPoolExecutor or manual threading needed
-5. **RequestContext provides session_id** - No need to manually pass session_id through payload, AgentCore provides it via `context.session_id`
-6. **asyncio.create_task() for fire-and-forget** - Cleaner than manual threading for background task execution
-
-**Note**: We haven't confirmed with the AgentCore service team whether using external loggers (like Powertools) is discouraged or problematic. The multiple streams appear to be related to AgentCore's internal architecture, not our logging choices.
+1. AgentCore's built-in logger works - Simple and integrates with AgentCore streams
+2. @app.async_task decorator is the recommended approach - Handles status automatically without manual task management
+3. Multiple log streams are normal - Agent-as-container pre-warms 10 execution environments; agent-as-code creates them on-demand
+4. Native async is cleaner - Strands has invoke_async, no ThreadPoolExecutor or manual threading needed
+5. RequestContext provides session_id - No need to manually pass it through payload
+6. asyncio.create_task for fire-and-forget - Cleaner than manual threading for background task execution
 
 ### What to Monitor
-- **otel-rt-logs stream** - Contains detailed execution telemetry
-- **Agent status transitions** - HEALTHY ↔ HEALTHY_BUSY (automatic via `@app.async_task`)
-- **Error logs** - Appear in both runtime-logs and otel-rt-logs streams
-- **DynamoDB event journal** - Workflow-level tracking (SESSION_INITIATED, AGENT_INVOCATION_STARTED, AGENT_BACKGROUND_TASK_COMPLETED, etc.)
-- **Step Function execution logs** - Orchestration-level visibility
+- OTEL logs stream: Contains detailed execution telemetry
+- Agent status transitions: HEALTHY ↔ HEALTHY_BUSY - automatic via @app.async_task
+- Error logs: Appear in both runtime logs and OTEL logs streams
+- DynamoDB event journal: Workflow-level tracking like SESSION_INITIATED, AGENT_INVOCATION_STARTED, AGENT_BACKGROUND_TASK_COMPLETED
+- Step Function execution logs: Orchestration-level visibility
 
 ## Resolved Questions
 
@@ -117,40 +116,45 @@ Agent-as-code deployment using `AgentRuntimeArtifact.fromS3()` in `infra/lib/age
 
 **Answer**: The number of log streams depends on the deployment method:
 
-**Agent-as-Container Deployment** (Docker image):
-- Creates **~11 log streams** (10 runtime + 1 OTEL)
-- AgentCore pre-warms **10 containers** for performance and scalability
-- Each container gets its own log stream with UUID: `runtime-logs-<UUID>`
-- Plus 1 OTEL stream for telemetry: `otel-rt-logs`
-- **Trade-off**: More log streams but better cold start performance
+**Agent-as-Container Deployment** - Docker image:
+- Creates ~11 log streams at deployment: 10 runtime + 1 OTEL
+- AgentCore pre-warms 10 containers for performance and scalability
+- Runtime log format: `YYYY/MM/DD/[runtime-logs-{SESSION_ID}]{EXECUTION_ENVIRONMENT_UUID}`
+- OTEL log format: `otel-rt-logs`
+- Trade-off: More log streams but better cold start performance
 
-**Agent-as-Code Deployment** (Python code via S3):
-- Creates **only 2 log streams** (1 runtime + 1 OTEL)
-- Single runtime stream: `runtime-logs-<UUID>`
-- Single OTEL stream: `otel-rt-logs`
-- **Trade-off**: Cleaner logs but potentially slower cold starts
+**Agent-as-Code Deployment** - Python code via S3:
+- OTEL stream created at deployment: `otel-rt-logs`
+- Runtime streams created on-demand per execution environment
+- Runtime log format: `YYYY/MM/DD/[runtime-logs-{SESSION_ID}]{EXECUTION_ENVIRONMENT_UUID}`
+- Trade-off: Fewer initial streams but potentially slower cold starts
 
 **Our Implementation**:
-We use **agent-as-code deployment** via `AgentRuntimeArtifact.fromS3()` in CDK, resulting in only 2 log streams.
+We use agent-as-code deployment via `AgentRuntimeArtifact.fromS3()` in CDK.
 
 **Impact**: 
-- Cleaner CloudWatch log groups (only 2 streams)
-- Easier to find relevant application logs
-- Lower CloudWatch costs
-- Simpler log management
+- Fewer initial log streams: 1 OTEL at deployment
+- Runtime streams created only when needed per execution environment
+- Lower initial CloudWatch costs
 
 **Key Learning**: 
-- The UUID in log stream names represents **container instances**, not session IDs or agent versions
-- Session IDs are tracked separately via `context.session_id` in the agent code
+- Runtime log stream format: `YYYY/MM/DD/[runtime-logs-{SESSION_ID}]{EXECUTION_ENVIRONMENT_UUID}`
+  - Example: `2025/12/02/[runtime-logs-f07e0b11-3090-d01d-78b7-ad8eaf4a93fd]d46c08d5-f8a1-4bb0-9b8f-c2d9519a7a95`
+- Execution environment behavior similar to AWS Lambda:
+  - Runtime log streams created per execution environment, not per session
+  - Created only after first invocation, not at deployment
+  - Same session can use different execution environments
+  - Concurrent requests for same session can use different environments
+  - Global state is not reliable - use external storage like DynamoDB and S3 for state persistence
 
 ## Conclusion
 
 The "multiple log streams issue" was not an issue but normal AgentCore behavior. Our various logging attempts were based on false assumptions about how AgentCore works. The simplest approach - using AgentCore's built-in logging (`app.logger`) and decorators (`@app.async_task`) - provides the best observability with minimal complexity.
 
 **Current Working Architecture**:
-- Using AgentCore's built-in logger (`app.logger`)
-- `@app.async_task` decorator manages status transitions automatically (HEALTHY ↔ HEALTHY_BUSY)
-- Fire-and-forget pattern using `asyncio.create_task()` for Lambda timeout avoidance
-- Native Strands `invoke_async()` methods for clean async execution
-- AgentCore `RequestContext` provides session_id automatically
-- DynamoDB event journaling for workflow tracking (complements AgentCore logs)
+- Using AgentCore's built-in logger: app.logger
+- @app.async_task decorator manages status transitions automatically: HEALTHY ↔ HEALTHY_BUSY
+- Fire-and-forget pattern using asyncio.create_task for Lambda timeout avoidance
+- Native Strands invoke_async methods for clean async execution
+- AgentCore RequestContext provides session_id automatically
+- DynamoDB event journaling for workflow tracking - complements AgentCore logs


### PR DESCRIPTION
**Issue number:** N/A

## Summary

### Changes

Clarified AgentCore Runtime logging behavior in documentation based on actual log stream format observations.

Updated `docs/agentcore_logging_investigation.md` and `docs/orchrestation_decisions_record.md` to:
- Document correct runtime log stream format: `YYYY/MM/DD/[runtime-logs-{SESSION_ID}]{EXECUTION_ENVIRONMENT_UUID}`
- Clarify that runtime log streams are created per execution environment, not per session
- Explain that same session ID can appear in multiple log streams with different execution environment UUIDs
- Remove incorrect assumptions about log stream naming conventions

### User experience

Before: Documentation incorrectly described log stream format and didn't explain execution environment behavior
After: Documentation accurately reflects AgentCore Runtime's execution environment model and log stream naming, helping developers understand why multiple log streams exist and why external storage is needed for state persistence

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
