### PR TITLE
refactor: remove injected timestamp with dedicated tool

### DIFF
--- a/src/agents/analysis_prompt.md
+++ b/src/agents/analysis_prompt.md
@@ -124,23 +124,6 @@ Use the journal tool to track your progress through the cost optimization workfl
 
 ## DETERMINISTIC WORKFLOW
 
-**CRITICAL: Time Calculation Setup**
-Before making ANY CloudWatch queries, use the time tools:
-- You are operating in real-time, analyzing current AWS resources
-- Call `current_time_unix_utc()` to get the CURRENT Unix timestamp
-- Use the returned timestamp as endTime for all CloudWatch queries
-- Use `calculator` to compute startTime by subtracting days
-- For 15-day window: 
-  1. `current_time = current_time_unix_utc()`
-  2. `startTime = calculator(expression="<current_time> - (15 * 86400)")`
-  3. `endTime = current_time`
-- For 30-day window:
-  1. `current_time = current_time_unix_utc()`
-  2. `startTime = calculator(expression="<current_time> - (30 * 86400)")`
-  3. `endTime = current_time`
-- NEVER use timestamps from examples, previous runs, or fixed dates
-- NEVER calculate time mentally - always use the tools
-
 1) Discovery (Inventory)
 
    **DISCOVERY PHASE - Task Tracking Start:**

--- a/src/agents/main.py
+++ b/src/agents/main.py
@@ -166,12 +166,7 @@ def _handle_background_task_error(
 # Decorator automatically manages AgentCore status: HEALTHY_BUSY while running, HEALTHY when complete
 @app.async_task
 async def background_task(user_message: str, session_id: str):
-    """Background task using workflow pattern.
-
-    Args:
-        user_message: User message from payload (passed but currently unused in predefined workflow)
-        session_id: Session ID for tracking and journaling
-    """
+    """Background task using workflow pattern."""
     logger.info(f"Background task started - Session: {session_id}")
 
     analysis_prompt, report_prompt = load_prompts()

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -4,9 +4,11 @@ Tools Package for the Agentic Cost Optimizer
 This package contains Strands tools for various operations:
 - journal: DynamoDB journaling tools for session and task tracking
 - storage: S3 file operations for reading and writing analysis data and reports
+- time_tools: Time utilities for Unix/ISO timestamp conversions
 """
 
 from .journal import journal
 from .storage import storage
+from .time_tools import convert_time_unix_to_iso, current_time_unix_utc
 
-__all__ = ["journal", "storage"]
+__all__ = ["journal", "storage", "current_time_unix_utc", "convert_time_unix_to_iso"]

--- a/src/tools/time_tools.py
+++ b/src/tools/time_tools.py
@@ -1,0 +1,36 @@
+"""Time Tools for Cost Optimization Agent"""
+
+import logging
+import time
+from datetime import datetime, timezone
+
+from strands import tool
+
+logger = logging.getLogger(__name__)
+
+
+@tool
+def current_time_unix_utc() -> int:
+    """Get the current Unix timestamp in UTC (seconds since epoch).
+
+    Returns:
+        int: Current Unix timestamp
+    """
+    timestamp = int(time.time())
+    logger.info(f"CURRENT_TIME_UNIX_UTC: {timestamp}")
+    return timestamp
+
+
+@tool
+def convert_time_unix_to_iso(unix_timestamp: int) -> str:
+    """Convert Unix timestamp to ISO 8601 format for AWS APIs.
+
+    Args:
+        unix_timestamp: Unix timestamp in seconds since epoch
+
+    Returns:
+        str: ISO 8601 formatted timestamp (e.g., '2025-11-28T11:18:45Z')
+    """
+    iso_time = datetime.fromtimestamp(unix_timestamp, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    logger.info(f"CONVERT_TIME_UNIX_TO_ISO: {unix_timestamp} → {iso_time}")
+    return iso_time

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,12 +7,27 @@ from unittest.mock import MagicMock
 
 
 def mock_tool_decorator(*args, **kwargs):
-    """Mock @tool decorator by doing nothing."""
+    """Mock @tool decorator that handles both @tool and @tool(context=True).
 
+    This decorator supports two usage patterns:
+    1. @tool - Direct decoration without arguments (e.g., time tools)
+    2. @tool(context=True) - Decoration with arguments (e.g., journal, storage)
+    """
+    # Case 1: @tool (direct decoration, first arg is the function)
+    if len(args) == 1 and callable(args[0]) and not kwargs:
+        f = args[0]
+
+        @wraps(f)
+        def decorated_function(*func_args, **func_kwargs):
+            return f(*func_args, **func_kwargs)
+
+        return decorated_function
+
+    # Case 2: @tool(context=True) (decorator with arguments)
     def decorator(f):
         @wraps(f)
-        def decorated_function(*args, **kwargs):
-            return f(*args, **kwargs)
+        def decorated_function(*func_args, **func_kwargs):
+            return f(*func_args, **func_kwargs)
 
         return decorated_function
 

--- a/tests/test_agent_invoke.py
+++ b/tests/test_agent_invoke.py
@@ -92,113 +92,58 @@ class TestInvokeFunction:
         assert result["session_id"] == "session-456"
 
 
-class TestCreateAgent:
-    """Test cases for create_agent function."""
+class TestAgentConfiguration:
+    """Test cases for agent configuration and setup."""
 
-    @patch("src.agents.main.BedrockModel")
-    @patch("src.agents.main.Agent")
-    def test_create_agent_with_empty_system_prompt(self, mock_agent, mock_bedrock_model):
-        """Test create_agent raises ValueError when system_prompt is empty."""
+    def test_create_agent_requires_system_prompt(self):
+        """Test that agent creation fails without a system prompt."""
         from src.agents.main import create_agent
 
         with pytest.raises(ValueError, match="system_prompt is required"):
             create_agent(system_prompt="")
-
-    @patch("src.agents.main.BedrockModel")
-    @patch("src.agents.main.Agent")
-    def test_create_agent_with_none_system_prompt(self, mock_agent, mock_bedrock_model):
-        """Test create_agent raises ValueError when system_prompt is None."""
-        from src.agents.main import create_agent
 
         with pytest.raises(ValueError, match="system_prompt is required"):
             create_agent(system_prompt=None)
 
     @patch("src.agents.main.Agent")
     @patch("src.agents.main.BedrockModel")
-    @patch("src.agents.main.config")
-    def test_create_agent_with_valid_prompt(self, mock_config, mock_bedrock_model_class, mock_agent_class):
-        """Test create_agent successfully creates agent with valid prompt."""
+    def test_create_agent_uses_default_boto_config(self, mock_bedrock_model, mock_agent):
+        """Test that agent creation uses default boto config when not provided."""
         from src.agents.main import create_agent
-
-        mock_config.model_id = "test-model-id"
-        mock_config.aws_region = "us-west-2"
-
-        mock_bedrock_instance = MagicMock()
-        mock_bedrock_model_class.return_value = mock_bedrock_instance
-
-        mock_agent_instance = MagicMock()
-        mock_agent_class.return_value = mock_agent_instance
-
-        result = create_agent(system_prompt="Test prompt", tools=[])
-
-        # Verify BedrockModel was created with correct parameters
-        mock_bedrock_model_class.assert_called_once()
-        call_kwargs = mock_bedrock_model_class.call_args.kwargs
-        assert call_kwargs["model_id"] == "test-model-id"
-        assert call_kwargs["region_name"] == "us-west-2"
-
-        # Verify Agent was created
-        mock_agent_class.assert_called_once()
-        agent_kwargs = mock_agent_class.call_args.kwargs
-        assert agent_kwargs["model"] == mock_bedrock_instance
-        assert agent_kwargs["system_prompt"] == "Test prompt"
-        assert agent_kwargs["tools"] == []
-
-        assert result == mock_agent_instance
-
-    @patch("src.agents.main.Agent")
-    @patch("src.agents.main.BedrockModel")
-    @patch("src.agents.main.config")
-    def test_create_agent_with_default_tools(self, mock_config, mock_bedrock_model_class, mock_agent_class):
-        """Test create_agent uses empty list when tools is None."""
-        from src.agents.main import create_agent
-
-        mock_config.model_id = "test-model-id"
-        mock_config.aws_region = "us-west-2"
-
-        mock_bedrock_instance = MagicMock()
-        mock_bedrock_model_class.return_value = mock_bedrock_instance
-
-        mock_agent_instance = MagicMock()
-        mock_agent_class.return_value = mock_agent_instance
 
         create_agent(system_prompt="Test prompt")
 
-        # Verify Agent was created with empty tools list
-        mock_agent_class.assert_called_once()
-        agent_kwargs = mock_agent_class.call_args.kwargs
-        assert agent_kwargs["tools"] == []
+        mock_bedrock_model.assert_called_once()
+        call_kwargs = mock_bedrock_model.call_args.kwargs
+        assert "boto_client_config" in call_kwargs
+        assert call_kwargs["boto_client_config"] is not None
 
+    @patch("src.agents.main.Agent")
+    @patch("src.agents.main.BedrockModel")
+    def test_create_agent_uses_provided_boto_config(self, mock_bedrock_model, mock_agent):
+        """Test that agent creation uses provided boto config."""
+        from botocore.config import Config as BotocoreConfig
 
-class TestLoadPrompts:
-    """Test cases for load_prompts function."""
+        from src.agents.main import create_agent
 
-    @patch("builtins.open")
-    def test_load_prompts_replaces_placeholders(self, mock_open):
-        """Test load_prompts replaces timestamp placeholders."""
-        from src.agents.main import load_prompts
+        custom_config = BotocoreConfig(retries={"max_attempts": 5})
+        create_agent(system_prompt="Test prompt", boto_config=custom_config)
 
-        mock_analysis_content = "Analysis at {current_timestamp} and {current_datetime}"
-        mock_report_content = "Report content"
+        mock_bedrock_model.assert_called_once()
+        call_kwargs = mock_bedrock_model.call_args.kwargs
+        assert call_kwargs["boto_client_config"] == custom_config
 
-        mock_file_analysis = MagicMock()
-        mock_file_analysis.read.return_value = mock_analysis_content
-        mock_file_analysis.__enter__.return_value = mock_file_analysis
-        mock_file_analysis.__exit__.return_value = None
+    @patch("src.agents.main.Agent")
+    @patch("src.agents.main.BedrockModel")
+    def test_create_agent_defaults_to_empty_tools(self, mock_bedrock_model, mock_agent):
+        """Test that agent creation defaults to empty tools list."""
+        from src.agents.main import create_agent
 
-        mock_file_report = MagicMock()
-        mock_file_report.read.return_value = mock_report_content
-        mock_file_report.__enter__.return_value = mock_file_report
-        mock_file_report.__exit__.return_value = None
+        create_agent(system_prompt="Test prompt")
 
-        mock_open.side_effect = [mock_file_analysis, mock_file_report]
-
-        analysis_prompt, report_prompt = load_prompts()
-
-        assert "{current_timestamp}" not in analysis_prompt
-        assert "{current_datetime}" not in analysis_prompt
-        assert "Analysis at" in analysis_prompt
-        assert report_prompt == mock_report_content
+        mock_agent.assert_called_once()
+        call_kwargs = mock_agent.call_args.kwargs
+        assert call_kwargs["tools"] == []
 
 
 class TestBackgroundTask:

--- a/tests/test_time_tools.py
+++ b/tests/test_time_tools.py
@@ -1,13 +1,8 @@
-"""
-Tests for time tools
-
-These tests verify the time tools work correctly through their public interface.
-"""
+"""Tests for time tools"""
 
 import time
 from datetime import datetime, timezone
 
-# Import the time tool functions - @tool decorator is mocked in conftest.py
 from src.tools.time_tools import convert_time_unix_to_iso, current_time_unix_utc
 
 
@@ -15,7 +10,6 @@ def test_current_time_unix_utc():
     """Test current_time_unix_utc returns valid Unix timestamp."""
     result = current_time_unix_utc()
 
-    # Verify it's an integer
     assert isinstance(result, int)
 
     # Verify it's a reasonable timestamp (after 2024-01-01)
@@ -32,7 +26,6 @@ def test_convert_time_unix_to_iso():
     unix_timestamp = 1733152725
     result = convert_time_unix_to_iso(unix_timestamp)
 
-    # Verify format
     assert isinstance(result, str)
     assert result == "2024-12-02T15:18:45Z"
 
@@ -44,13 +37,10 @@ def test_convert_time_unix_to_iso():
 
 def test_convert_time_unix_to_iso_with_current_time():
     """Test conversion with current time to ensure consistency."""
-    # Get current timestamp
     unix_timestamp = current_time_unix_utc()
 
-    # Convert to ISO
     iso_time = convert_time_unix_to_iso(unix_timestamp)
 
-    # Parse back and verify it matches
     parsed_time = datetime.strptime(iso_time, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
     parsed_unix = int(parsed_time.timestamp())
 
@@ -95,17 +85,14 @@ def test_time_range_calculation_pattern():
 
 def test_iso_format_consistency():
     """Test that ISO format is consistent and parseable."""
-    # Test various timestamps
     test_timestamps = [0, 1704067200, 1733152725, 1735689600]
 
     for ts in test_timestamps:
         iso_str = convert_time_unix_to_iso(ts)
 
-        # Verify format
         assert iso_str.endswith("Z")
         assert "T" in iso_str
         assert len(iso_str) == 20
 
-        # Verify it can be parsed back
         parsed = datetime.strptime(iso_str, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
         assert int(parsed.timestamp()) == ts

--- a/tests/test_time_tools.py
+++ b/tests/test_time_tools.py
@@ -1,0 +1,111 @@
+"""
+Tests for time tools
+
+These tests verify the time tools work correctly through their public interface.
+"""
+
+import time
+from datetime import datetime, timezone
+
+# Import the time tool functions - @tool decorator is mocked in conftest.py
+from src.tools.time_tools import convert_time_unix_to_iso, current_time_unix_utc
+
+
+def test_current_time_unix_utc():
+    """Test current_time_unix_utc returns valid Unix timestamp."""
+    result = current_time_unix_utc()
+
+    # Verify it's an integer
+    assert isinstance(result, int)
+
+    # Verify it's a reasonable timestamp (after 2024-01-01)
+    assert result > 1704067200  # 2024-01-01 00:00:00 UTC
+
+    # Verify it's close to now (within 2 seconds)
+    actual_time = int(time.time())
+    assert abs(result - actual_time) <= 2
+
+
+def test_convert_time_unix_to_iso():
+    """Test Unix timestamp to ISO 8601 conversion."""
+    # Test with a known timestamp: 2024-12-02 15:18:45 UTC
+    unix_timestamp = 1733152725
+    result = convert_time_unix_to_iso(unix_timestamp)
+
+    # Verify format
+    assert isinstance(result, str)
+    assert result == "2024-12-02T15:18:45Z"
+
+    # Verify it matches expected ISO format pattern
+    assert len(result) == 20
+    assert result.endswith("Z")
+    assert "T" in result
+
+
+def test_convert_time_unix_to_iso_with_current_time():
+    """Test conversion with current time to ensure consistency."""
+    # Get current timestamp
+    unix_timestamp = current_time_unix_utc()
+
+    # Convert to ISO
+    iso_time = convert_time_unix_to_iso(unix_timestamp)
+
+    # Parse back and verify it matches
+    parsed_time = datetime.strptime(iso_time, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    parsed_unix = int(parsed_time.timestamp())
+
+    # Should match within 1 second (accounting for execution time)
+    assert abs(parsed_unix - unix_timestamp) <= 1
+
+
+def test_convert_time_unix_to_iso_edge_cases():
+    """Test conversion with various edge case timestamps."""
+    # Test epoch (1970-01-01 00:00:00 UTC)
+    assert convert_time_unix_to_iso(0) == "1970-01-01T00:00:00Z"
+
+    # Test a specific date: 2025-01-01 00:00:00 UTC
+    assert convert_time_unix_to_iso(1735689600) == "2025-01-01T00:00:00Z"
+
+    # Test another specific date: 2024-06-15 12:30:45 UTC
+    assert convert_time_unix_to_iso(1718454645) == "2024-06-15T12:30:45Z"
+
+
+def test_time_range_calculation_pattern():
+    """Test the pattern used in prompts for time range calculations."""
+    # This simulates how the agent would use the tools
+    current_time = current_time_unix_utc()
+
+    # Calculate 30 days back (as the agent would with calculator)
+    thirty_days_seconds = 30 * 86400
+    start_time = current_time - thirty_days_seconds
+
+    # Verify the calculation makes sense
+    assert start_time < current_time
+    assert (current_time - start_time) == thirty_days_seconds
+
+    # Convert both to ISO for AWS APIs that need it
+    start_iso = convert_time_unix_to_iso(start_time)
+    end_iso = convert_time_unix_to_iso(current_time)
+
+    # Verify both are valid ISO strings
+    assert start_iso.endswith("Z")
+    assert end_iso.endswith("Z")
+    assert start_iso < end_iso  # Lexicographic comparison works for ISO format
+
+
+def test_iso_format_consistency():
+    """Test that ISO format is consistent and parseable."""
+    # Test various timestamps
+    test_timestamps = [0, 1704067200, 1733152725, 1735689600]
+
+    for ts in test_timestamps:
+        iso_str = convert_time_unix_to_iso(ts)
+
+        # Verify format
+        assert iso_str.endswith("Z")
+        assert "T" in iso_str
+        assert len(iso_str) == 20
+
+        # Verify it can be parsed back
+        parsed = datetime.strptime(iso_str, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+        assert int(parsed.timestamp()) == ts


### PR DESCRIPTION
**Issue number:** n/a

## Summary

### Changes

Replaced hardcoded timestamp placeholders in prompts with dedicated time tools to prevent LLM hallucination when calculating time ranges for CloudWatch queries.

**Key Changes:**
- Created `src/tools/time_tools.py` with two new tools:
  - `current_time_unix_utc()` - Returns current Unix timestamp
  - `convert_time_unix_to_iso()` - Converts Unix timestamps to ISO 8601 format
- Updated `src/agents/main.py`:
  - Removed timestamp placeholder replacement logic from `load_prompts()`
  - Added time tools to analysis agent's tool list
  - Added explicit UTF-8 encoding for file operations
- Updated `src/agents/analysis_prompt.md`:
  - Removed hardcoded timestamp placeholders
  - Added instructions for using time tools
- Added test coverage in `tests/test_time_tools.py`
- Updated `tests/conftest.py` to properly mock both `@tool` and `@tool(context=True)` decorators

### User experience

**Before:**
- Timestamps were injected into prompts at runtime
- Agent could hallucinate when calculating time ranges (e.g., "let me extend the time range...")
- No visibility into time calculations
- Inconsistent behavior when queries failed and needed retry with different time ranges

**After:**
- Agent explicitly calls `current_time_unix_utc()` to get current time
- Agent uses `calculator` tool for all time arithmetic (no mental math)
- Agent can get fresh timestamps when retrying failed queries
- Supports both Unix and ISO 8601 formats for different AWS APIs

**Example Agent Execution:**
```json
{
  "toolUse": {"name": "current_time_unix_utc", "input": {}},
  "toolResult": {"content": [{"text": "1764693227"}]}
},
{
  "toolUse": {
    "name": "calculator",
    "input": {"expression": "1764693227 - (30 * 86400)"}
  },
  "toolResult": {"content": [{"text": "Result: 1762101227"}]}
}
