### PR TITLE
feat: add github actions deployemnt job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,14 @@ permissions:
   contents: read
 
 on:
-  pull_request:
-    branches:
-      - main
+  # Manual trigger for testing PRs - reviewer runs against specific commit SHA
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: 'Commit SHA to test (from PR)'
+        required: true
+        type: string
+  # Automatic on push to main (after PR merge)
   push:
     branches:
       - main
@@ -14,12 +19,11 @@ on:
 jobs:
   test-python:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          ref: ${{ inputs.sha || github.sha }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244 # v7.1.4
@@ -37,19 +41,13 @@ jobs:
       - name: Run tests
         run: uv run pytest tests/ -v --cov=src --cov-report=term --cov-report=xml --junitxml=test-results.xml
 
-      - name: Coverage comment
-        if: github.event_name == 'pull_request'
-        uses: py-cov-action/python-coverage-comment-action@a6a4209d6d08f73ae4b29d2cf53377002b44bd8f # v3
-        with:
-          GITHUB_TOKEN: ${{ github.token }}
-          MINIMUM_GREEN: 90
-          MINIMUM_ORANGE: 70
-
   test-typescript:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          ref: ${{ inputs.sha || github.sha }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244 # v7.1.4
@@ -81,6 +79,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          ref: ${{ inputs.sha || github.sha }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244 # v7.1.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,26 +107,26 @@ jobs:
         run: npm run synth > /dev/null
         working-directory: infra
 
-  deploy-dev:
+  deploy-staging:
     runs-on: ubuntu-latest
     needs: [test-python, test-typescript, test-cdk-nag]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    environment: dev
+    environment: staging
     concurrency:
-      group: deploy-dev
+      group: deploy-staging
       cancel-in-progress: false
     steps:
-      # TODO: Implement dev deployment when dev account is available
-      - name: Placeholder - Deploy to dev
-        run: echo "Dev deployment placeholder - implement when dev account is ready"
+      # TODO: Implement staging deployment when staging account is available
+      - name: Placeholder - Deploy to staging
+        run: echo "Staging deployment placeholder - implement when staging account is ready"
 
   test-integration:
     runs-on: ubuntu-latest
-    needs: [deploy-dev]
+    needs: [deploy-staging]
     steps:
-      # TODO: Implement integration tests against dev environment
+      # TODO: Implement integration tests against staging environment
       - name: Placeholder - Integration tests
-        run: echo "Integration tests placeholder - implement when dev environment is deployed"
+        run: echo "Integration tests placeholder - implement when staging environment is deployed"
 
   deploy-prod:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,13 +112,49 @@ jobs:
     needs: [test-python, test-typescript, test-cdk-nag]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment: staging
+    permissions:
+      contents: read
+      id-token: write
     concurrency:
       group: deploy-staging
       cancel-in-progress: false
     steps:
-      # TODO: Implement staging deployment when staging account is available
-      - name: Placeholder - Deploy to staging
-        run: echo "Staging deployment placeholder - implement when staging account is ready"
+      - name: Checkout code
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+          audience: sts.amazonaws.com
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244 # v7.1.4
+        with:
+          python-version: "3.12"
+          enable-cache: true
+          prune-cache: false
+          cache-dependency-glob: |
+            uv.lock
+            pyproject.toml
+
+      - name: Setup Node.js
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: infra/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: infra
+
+      - name: Deploy to AWS
+        run: npm run deploy
+        working-directory: infra
+        env:
+          ENVIRONMENT: staging
 
   test-integration:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [python-tests, typescript-tests, cdk-nag-test]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # TODO: Restore after testing: if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push'
     environment: dev
     concurrency:
       group: deploy-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,9 @@ permissions:
   contents: read
 
 on:
-  # Manual trigger for testing PRs - reviewer runs against specific commit SHA
-  workflow_dispatch:
-    inputs:
-      sha:
-        description: 'Commit SHA to test (from PR)'
-        required: true
-        type: string
-  # Automatic on push to main (after PR merge)
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
@@ -19,11 +14,12 @@ on:
 jobs:
   test-python:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-        with:
-          ref: ${{ inputs.sha || github.sha }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244 # v7.1.4
@@ -41,13 +37,19 @@ jobs:
       - name: Run tests
         run: uv run pytest tests/ -v --cov=src --cov-report=term --cov-report=xml --junitxml=test-results.xml
 
+      - name: Coverage comment
+        if: github.event_name == 'pull_request'
+        uses: py-cov-action/python-coverage-comment-action@a6a4209d6d08f73ae4b29d2cf53377002b44bd8f # v3
+        with:
+          GITHUB_TOKEN: ${{ github.token }}
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 70
+
   test-typescript:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-        with:
-          ref: ${{ inputs.sha || github.sha }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244 # v7.1.4
@@ -79,8 +81,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-        with:
-          ref: ${{ inputs.sha || github.sha }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244 # v7.1.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 
 permissions:
   contents: read
-  pull-requests: write
-  id-token: write
 
 on:
   pull_request:
@@ -16,6 +14,9 @@ on:
 jobs:
   test-python:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -131,6 +132,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test-integration]
     environment: prod
+    permissions:
+      contents: read
+      id-token: write
     concurrency:
       group: deploy-prod
       cancel-in-progress: false
@@ -171,22 +175,3 @@ jobs:
         working-directory: infra
         env:
           ENVIRONMENT: prod
-
-  release:
-    runs-on: ubuntu-latest
-    needs: [deploy-prod]
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-
-      - name: Create release tag
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          TAG_NAME="v$(date +%Y.%m.%d).${{ github.run_number }}"
-          gh release create "$TAG_NAME" \
-            --title "Release $TAG_NAME" \
-            --notes "Automated release after successful prod deployment" \
-            --target ${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 
 on:
   pull_request:
@@ -104,3 +105,46 @@ jobs:
       - name: Run CDK Nag checks
         run: npm run synth > /dev/null
         working-directory: infra
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [python-tests, typescript-tests, cdk-nag-test]
+    # TODO: Revert after testing - should be: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/rezabekf/configure-deployment-to-aws'
+    environment: dev
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244 # v7.1.4
+        with:
+          python-version: "3.12"
+          enable-cache: true
+          prune-cache: false
+          cache-dependency-glob: |
+            uv.lock
+            pyproject.toml
+
+      - name: Setup Node.js
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: infra/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: infra
+
+      - name: Deploy to AWS
+        run: npm run deploy
+        working-directory: infra
+        env:
+          ENVIRONMENT: dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
+          audience: sts.amazonaws.com
 
       - name: Install uv
         uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244 # v7.1.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,9 +109,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [python-tests, typescript-tests, cdk-nag-test]
-    # TODO: Restore after testing: if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    if: github.ref == 'refs/heads/main' || github.head_ref == 'rezabekf/configure-deployment-to-aws'
-
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment: dev
     concurrency:
       group: deploy-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,15 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'src/**'
+      - 'infra/**'
+      - 'tests/**'
+      - 'evals/**'
+      - 'scripts/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/ci.yml'
 
 jobs:
   test-python:
@@ -156,17 +165,9 @@ jobs:
         env:
           ENVIRONMENT: staging
 
-  test-integration:
-    runs-on: ubuntu-latest
-    needs: [deploy-staging]
-    steps:
-      # TODO: Implement integration tests against staging environment
-      - name: Placeholder - Integration tests
-        run: echo "Integration tests placeholder - implement when staging environment is deployed"
-
   deploy-prod:
     runs-on: ubuntu-latest
-    needs: [test-integration]
+    needs: [deploy-staging]
     environment: prod
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,10 +106,31 @@ jobs:
         run: npm run synth > /dev/null
         working-directory: infra
 
-  deploy:
+  # Deployment Pipeline: dev -> integ tests -> prod -> release
+  deploy-dev:
     runs-on: ubuntu-latest
     needs: [python-tests, typescript-tests, cdk-nag-test]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    environment: dev
+    concurrency:
+      group: deploy-dev
+      cancel-in-progress: false
+    steps:
+      # TODO: Implement dev deployment when dev account is available
+      - name: Placeholder - Deploy to dev
+        run: echo "Dev deployment placeholder - implement when dev account is ready"
+
+  integration-tests:
+    runs-on: ubuntu-latest
+    needs: [deploy-dev]
+    steps:
+      # TODO: Implement integration tests against dev environment
+      - name: Placeholder - Integration tests
+        run: echo "Integration tests placeholder - implement when dev environment is deployed"
+
+  deploy-prod:
+    runs-on: ubuntu-latest
+    needs: [integration-tests]
     environment: prod
     concurrency:
       group: deploy-prod
@@ -151,3 +172,22 @@ jobs:
         working-directory: infra
         env:
           ENVIRONMENT: prod
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [deploy-prod]
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+
+      - name: Create release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG_NAME="v$(date +%Y.%m.%d).${{ github.run_number }}"
+          gh release create "$TAG_NAME" \
+            --title "Release $TAG_NAME" \
+            --notes "Automated release after successful prod deployment" \
+            --target ${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Coverage comment
         if: github.event_name == 'pull_request'
-        uses: py-cov-action/python-coverage-comment-action@v3
+        uses: py-cov-action/python-coverage-comment-action@a6a4209d6d08f73ae4b29d2cf53377002b44bd8f # v3
         with:
           GITHUB_TOKEN: ${{ github.token }}
           MINIMUM_GREEN: 90

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
       - main
 
 jobs:
-  python-tests:
+  test-python:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -44,7 +44,7 @@ jobs:
           MINIMUM_GREEN: 90
           MINIMUM_ORANGE: 70
 
-  typescript-tests:
+  test-typescript:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -75,7 +75,7 @@ jobs:
         run: npm test
         working-directory: infra
 
-  cdk-nag-test:
+  test-cdk-nag:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -106,10 +106,9 @@ jobs:
         run: npm run synth > /dev/null
         working-directory: infra
 
-  # Deployment Pipeline: dev -> integ tests -> prod -> release
   deploy-dev:
     runs-on: ubuntu-latest
-    needs: [python-tests, typescript-tests, cdk-nag-test]
+    needs: [test-python, test-typescript, test-cdk-nag]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment: dev
     concurrency:
@@ -120,7 +119,7 @@ jobs:
       - name: Placeholder - Deploy to dev
         run: echo "Dev deployment placeholder - implement when dev account is ready"
 
-  integration-tests:
+  test-integration:
     runs-on: ubuntu-latest
     needs: [deploy-dev]
     steps:
@@ -130,7 +129,7 @@ jobs:
 
   deploy-prod:
     runs-on: ubuntu-latest
-    needs: [integration-tests]
+    needs: [test-integration]
     environment: prod
     concurrency:
       group: deploy-prod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [python-tests, typescript-tests, cdk-nag-test]
     # TODO: Restore after testing: if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    if: github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' || github.head_ref == 'rezabekf/configure-deployment-to-aws'
+
     environment: dev
     concurrency:
       group: deploy-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,9 +110,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [python-tests, typescript-tests, cdk-nag-test]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    environment: dev
+    environment: prod
     concurrency:
-      group: deploy-dev
+      group: deploy-prod
       cancel-in-progress: false
     steps:
       - name: Checkout code
@@ -150,4 +150,4 @@ jobs:
         run: npm run deploy
         working-directory: infra
         env:
-          ENVIRONMENT: dev
+          ENVIRONMENT: prod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,9 +109,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [python-tests, typescript-tests, cdk-nag-test]
-    # TODO: Revert after testing - should be: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    if: github.ref == 'refs/heads/main' || github.head_ref == 'rezabekf/configure-deployment-to-aws'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment: dev
+    concurrency:
+      group: deploy-dev
+      cancel-in-progress: false
     steps:
       - name: Checkout code
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [python-tests, typescript-tests, cdk-nag-test]
     # TODO: Revert after testing - should be: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/rezabekf/configure-deployment-to-aws'
+    if: github.ref == 'refs/heads/main' || github.head_ref == 'rezabekf/configure-deployment-to-aws'
     environment: dev
     steps:
       - name: Checkout code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,15 +6,13 @@ documentation, we greatly value feedback and contributions from our community.
 Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
 information to effectively respond to your bug report or contribution.
 
-> **For local development setup instructions**, see [Local Development Guide](docs/LOCAL_DEVELOPMENT.md).
-
-
 ## Reporting Bugs/Feature Requests
 
 We welcome you to use the GitHub issue tracker to report bugs or suggest features.
 
 When filing an issue, please check existing open, or recently closed, issues to make sure somebody else hasn't already
 reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
+
 
 * A reproducible test case or series of steps
 * The version of our code being used

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ setup: init pre-commit-install
 
 init:
 	uv sync --group agents --group dev
-	cd infra && npm install
+	npm install --prefix infra
 	@echo "✓ Python deps installed in .venv/"
 	@echo "✓ Node deps installed in infra/"
 
@@ -47,7 +47,7 @@ test:
 	@echo "Running Python tests with coverage..."
 	uv run pytest tests/ --cov=src --cov-report=term-missing
 	@echo "Running TypeScript tests..."
-	cd infra && npm test
+	npm test --prefix infra
 	@echo "✓ All tests completed!"
 
 run-agent-local:
@@ -61,9 +61,9 @@ invoke-agent-local:
 		-d '{}'
 
 
-cdk-bootstrap: 
+cdk-bootstrap:
 	@echo "Bootstrapping CDK..."
-	cd infra && npm run build && npx cdk bootstrap
+	npm run cdk --prefix infra -- bootstrap
 	@echo "✓ CDK bootstrap completed"
 
 cdk-deploy:
@@ -72,16 +72,16 @@ cdk-deploy:
 	npm run deploy --prefix infra
 	@echo "✓ CDK deployment completed"
 
-cdk-hotswap: 
+cdk-hotswap:
 	@echo "Fast deploying Lambda changes..."
 	@echo "Environment: $(or $(ENVIRONMENT),dev), Version: $(or $(VERSION),v1)"
-	npx cdk deploy --hotswap --prefix infra
+	npm run deploy --prefix infra -- --hotswap
 	@echo "✓ CDK hotswap deployment completed"
 
-cdk-watch: 
+cdk-watch:
 	@echo "Starting CDK watch mode..."
 	@echo "Environment: $(or $(ENVIRONMENT),dev), Version: $(or $(VERSION),v1)"
-	npx cdk watch --prefix infra
+	npm run cdk --prefix infra -- watch
 
 cdk-destroy: 
 	@echo "Destroying CDK stack..."

--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ aws events put-events --entries '[{
 }]'
 ```
 
+## CI/CD Pipeline (Optional)
+
+The project includes GitHub Actions workflows for automated deployment using OIDC authentication (no stored credentials). See [CI/CD Pipeline Guide](docs/cicd_pipeline.md) for setup instructions.
+
 ## Monitoring
 
 Check the Step Functions console for workflow execution status. View reports in the Amazon S3 bucket (output in CDK deployment). Query Amazon DynamoDB for event history and audit trails.

--- a/docs/cicd_pipeline.md
+++ b/docs/cicd_pipeline.md
@@ -1,0 +1,51 @@
+# CI/CD Pipeline
+
+## Environments
+
+| Environment | Purpose | OIDC Setup | Deployed via |
+|-------------|---------|------------|--------------|
+| `dev` | Local development | No | Manual (`npm run deploy`) |
+| `staging` | Pre-prod testing, integ tests | Yes | CI/CD on merge to main |
+| `prod` | Production | Yes | CI/CD after staging tests pass |
+
+## Prerequisites (One-time setup per AWS account)
+
+1. Bootstrap CDK in each account: `cdk bootstrap`
+2. Deploy OIDC stack for CI/CD environments:
+   - `ENVIRONMENT=staging npm run deploy:oidc --prefix infra` (staging account)
+   - `ENVIRONMENT=prod npm run deploy:oidc --prefix infra` (prod account)
+3. Create GitHub environments (`staging`, `prod`) with `AWS_ROLE_ARN` secret from each OIDC stack output
+4. Configure environment protection rules (limit deployments to `main` branch only)
+5. Configure branch protection rules on `main` (require PR reviews, status checks)
+
+## Pipeline Flow
+
+### 1. PR Created/Updated
+
+- Runs: `test-python`, `test-typescript`, `test-cdk-nag`
+- No deployment, no AWS credentials needed
+
+### 2. PR Merged to Main
+
+- Unit tests run again
+- `deploy-staging` → deploys to staging account (GitHub environment: `staging`)
+- `test-integration` → runs integration/eval tests against staging
+- `deploy-prod` → deploys to prod account (GitHub environment: `prod`)
+
+## GitHub Environments
+
+Two environments (`staging`, `prod`) provide isolation with separate secrets, protection rules, and deployment history per environment.
+
+## Rollback Strategy
+
+- **Option 1:** Create a revert PR (`git revert <bad-commit>`) → merge to main → triggers full pipeline
+- **Option 2:** Re-run previous successful workflow from GitHub Actions UI (runs retained for 90 days by default)
+
+## Security
+
+- **No long-lived credentials:** OIDC authentication eliminates stored AWS access keys
+- **Environment isolation:** Each AWS account has its own OIDC role scoped to its GitHub environment
+- **Least privilege:** GitHub Actions role can only assume CDK bootstrap roles, not direct resource access
+- **Supply chain protection:** All GitHub Actions are pinned to SHA hashes
+- **Branch protection:** Deployments only trigger on push to `main` (requires PR merge)
+- **Concurrency control:** Prevents parallel deployments to the same environment

--- a/docs/cicd_pipeline.md
+++ b/docs/cicd_pipeline.md
@@ -49,3 +49,15 @@ Two environments (`staging`, `prod`) provide isolation with separate secrets, pr
 - **Supply chain protection:** All GitHub Actions are pinned to SHA hashes
 - **Branch protection:** Deployments only trigger on push to `main` (requires PR merge)
 - **Concurrency control:** Prevents parallel deployments to the same environment
+
+### Fork PR Protection
+
+Fork PRs require manual approval before workflows run. This is controlled by a repo-level setting, not the workflow file itself.
+
+**Required setting:** Settings → Actions → General → "Require approval for all external contributors"
+
+This ensures:
+- Every push from a fork requires maintainer approval
+- Every new PR from a fork requires approval
+- Malicious workflow modifications in forks cannot execute without review
+- Maintainers can inspect the diff (including `.github/workflows/`) before approving

--- a/infra/bin/github-oidc.ts
+++ b/infra/bin/github-oidc.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
+import { AwsSolutionsChecks } from 'cdk-nag';
 
 import { GitHubOidcStack } from '../lib/github-oidc-stack';
 
@@ -29,3 +30,5 @@ new GitHubOidcStack(app, 'GitHubOidcStack', {
     region: process.env.CDK_DEFAULT_REGION,
   },
 });
+
+cdk.Aspects.of(app).add(new AwsSolutionsChecks({ verbose: true }));

--- a/infra/bin/github-oidc.ts
+++ b/infra/bin/github-oidc.ts
@@ -15,7 +15,6 @@ import { GitHubOidcStack } from '../lib/github-oidc-stack';
  *   ENVIRONMENT=staging npm run deploy:oidc --prefix infra
  *   ENVIRONMENT=prod npm run deploy:oidc --prefix infra
  *
- * Note: 'dev' environment is for local development and does not use OIDC.
  *
  * After deployment:
  * 1. Copy the RoleArn from the stack outputs

--- a/infra/bin/github-oidc.ts
+++ b/infra/bin/github-oidc.ts
@@ -12,19 +12,28 @@ import { GitHubOidcStack } from '../lib/github-oidc-stack';
  * 2. IAM Role that GitHub Actions can assume
  *
  * Usage:
- *   npx cdk deploy --app "npx ts-node bin/github-oidc.ts"
+ *   ENVIRONMENT=prod/dev npm run deploy:oidc --prefix infra
  *
  * After deployment:
  * 1. Copy the RoleArn from the stack outputs
- * 2. Add it as a GitHub secret named AWS_ROLE_ARN
+ * 2. Add it as a GitHub secret named AWS_ROLE_ARN in the corresponding GitHub environment
  */
+
+const environment = process.env.ENVIRONMENT;
+if (!environment) {
+  console.error('\nENVIRONMENT is required.\n');
+  console.error('Usage: ENVIRONMENT=prod npm run deploy:oidc --prefix infra');
+  console.error('       ENVIRONMENT=dev npm run deploy:oidc --prefix infra\n');
+  process.exit(1);
+}
+
 const app = new cdk.App();
 
-new GitHubOidcStack(app, 'GitHubOidcStack', {
-  description: 'GitHub OIDC provider and IAM role for GitHub Actions deployments',
+new GitHubOidcStack(app, `GitHubOidcStack-${environment}`, {
+  description: `GitHub OIDC provider and IAM role for GitHub Actions deployments (${environment})`,
   githubOrg: 'aws-samples',
   githubRepo: 'sample-agentic-cost-optimizer',
-  environment: 'dev',
+  environment,
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION,

--- a/infra/bin/github-oidc.ts
+++ b/infra/bin/github-oidc.ts
@@ -23,7 +23,7 @@ new GitHubOidcStack(app, 'GitHubOidcStack', {
   description: 'GitHub OIDC provider and IAM role for GitHub Actions deployments',
   githubOrg: 'aws-samples',
   githubRepo: 'sample-agentic-cost-optimizer',
-  allowedBranch: 'main',
+  environment: 'dev',
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION,

--- a/infra/bin/github-oidc.ts
+++ b/infra/bin/github-oidc.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+
+import { GitHubOidcStack } from '../lib/github-oidc-stack';
+
+/**
+ * GitHub OIDC Setup for GitHub Actions deployments.
+ *
+ * This is a one-time setup (similar to CDK bootstrap) that creates:
+ * 1. GitHub OIDC Identity Provider in AWS
+ * 2. IAM Role that GitHub Actions can assume
+ *
+ * Usage:
+ *   npx cdk deploy --app "npx ts-node bin/github-oidc.ts"
+ *
+ * After deployment:
+ * 1. Copy the RoleArn from the stack outputs
+ * 2. Add it as a GitHub secret named AWS_ROLE_ARN
+ */
+const app = new cdk.App();
+
+new GitHubOidcStack(app, 'GitHubOidcStack', {
+  description: 'GitHub OIDC provider and IAM role for GitHub Actions deployments',
+  githubOrg: 'aws-samples',
+  githubRepo: 'sample-agentic-cost-optimizer',
+  allowedBranch: 'main',
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEFAULT_REGION,
+  },
+});

--- a/infra/bin/github-oidc.ts
+++ b/infra/bin/github-oidc.ts
@@ -12,18 +12,23 @@ import { GitHubOidcStack } from '../lib/github-oidc-stack';
  * 2. IAM Role that GitHub Actions can assume
  *
  * Usage:
- *   ENVIRONMENT=prod/dev npm run deploy:oidc --prefix infra
+ *   ENVIRONMENT=staging npm run deploy:oidc --prefix infra
+ *   ENVIRONMENT=prod npm run deploy:oidc --prefix infra
+ *
+ * Note: 'dev' environment is for local development and does not use OIDC.
  *
  * After deployment:
  * 1. Copy the RoleArn from the stack outputs
  * 2. Add it as a GitHub secret named AWS_ROLE_ARN in the corresponding GitHub environment
  */
 
+const VALID_ENVIRONMENTS = ['staging', 'prod'];
 const environment = process.env.ENVIRONMENT;
-if (!environment) {
-  console.error('\nENVIRONMENT is required.\n');
-  console.error('Usage: ENVIRONMENT=prod npm run deploy:oidc --prefix infra');
-  console.error('       ENVIRONMENT=dev npm run deploy:oidc --prefix infra\n');
+
+if (!environment || !VALID_ENVIRONMENTS.includes(environment)) {
+  console.error('\nENVIRONMENT must be "staging" or "prod".\n');
+  console.error('Usage: ENVIRONMENT=staging npm run deploy:oidc --prefix infra');
+  console.error('       ENVIRONMENT=prod npm run deploy:oidc --prefix infra\n');
   process.exit(1);
 }
 

--- a/infra/lib/github-oidc-stack.ts
+++ b/infra/lib/github-oidc-stack.ts
@@ -1,4 +1,5 @@
 import * as cdk from 'aws-cdk-lib';
+import { NagSuppressions } from 'cdk-nag';
 import { Construct } from 'constructs';
 
 import * as iam from 'aws-cdk-lib/aws-iam';
@@ -97,5 +98,25 @@ export class GitHubOidcStack extends cdk.Stack {
       description: 'ARN of the GitHub OIDC provider',
       exportName: 'GitHubOidcProviderArn',
     });
+
+    // CDK Nag suppressions
+    // NOTE: This is a sample for demonstration purposes. Review and adjust for production use.
+    NagSuppressions.addResourceSuppressions(
+      this.role,
+      [
+        {
+          id: 'AwsSolutions-IAM5',
+          reason:
+            'Sample code: Wildcard in CDK bootstrap role names is required because the qualifier varies per bootstrap. Roles are scoped to specific account/region. See: https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping.html',
+          appliesTo: [
+            'Resource::arn:aws:iam::<AWS::AccountId>:role/cdk-*-deploy-role-<AWS::AccountId>-<AWS::Region>',
+            'Resource::arn:aws:iam::<AWS::AccountId>:role/cdk-*-file-publishing-role-<AWS::AccountId>-<AWS::Region>',
+            'Resource::arn:aws:iam::<AWS::AccountId>:role/cdk-*-image-publishing-role-<AWS::AccountId>-<AWS::Region>',
+            'Resource::arn:aws:iam::<AWS::AccountId>:role/cdk-*-lookup-role-<AWS::AccountId>-<AWS::Region>',
+          ],
+        },
+      ],
+      true,
+    );
   }
 }

--- a/infra/lib/github-oidc-stack.ts
+++ b/infra/lib/github-oidc-stack.ts
@@ -57,14 +57,8 @@ export class GitHubOidcStack extends cdk.Stack {
             'token.actions.githubusercontent.com:aud': 'sts.amazonaws.com',
           },
           StringLike: {
-            // Scope to specific repo and branch
-            // Format: repo:<owner>/<repo>:ref:refs/heads/<branch>
-            // For PRs, GitHub uses: repo:<owner>/<repo>:pull_request
-            'token.actions.githubusercontent.com:sub': [
-              `repo:${githubOrg}/${githubRepo}:ref:refs/heads/${allowedBranch}`,
-              // TODO: Remove after testing - temporary for PR testing
-              `repo:${githubOrg}/${githubRepo}:pull_request`,
-            ],
+            // With GitHub Environments, subject format is: repo:<owner>/<repo>:environment:<name>
+            'token.actions.githubusercontent.com:sub': `repo:${githubOrg}/${githubRepo}:environment:dev`,
           },
         },
         'sts:AssumeRoleWithWebIdentity',

--- a/infra/lib/github-oidc-stack.ts
+++ b/infra/lib/github-oidc-stack.ts
@@ -62,8 +62,8 @@ export class GitHubOidcStack extends cdk.Stack {
             // For PRs, GitHub uses: repo:<owner>/<repo>:pull_request
             'token.actions.githubusercontent.com:sub': [
               `repo:${githubOrg}/${githubRepo}:ref:refs/heads/${allowedBranch}`,
-              // TODO: Remove after testing - temporary branch for PR testing
-              `repo:${githubOrg}/${githubRepo}:ref:refs/heads/rezabekf/configure-deployment-to-aws`,
+              // TODO: Remove after testing - temporary for PR testing
+              `repo:${githubOrg}/${githubRepo}:pull_request`,
             ],
           },
         },

--- a/infra/lib/github-oidc-stack.ts
+++ b/infra/lib/github-oidc-stack.ts
@@ -16,7 +16,7 @@ export interface GitHubOidcStackProps extends cdk.StackProps {
   readonly githubRepo: string;
 
   /**
-   * GitHub environment name for OIDC subject claim (e.g., 'dev', 'prod')
+   * GitHub environment name for OIDC subject claim (e.g., 'staging', 'prod')
    */
   readonly environment: string;
 }
@@ -27,7 +27,7 @@ export interface GitHubOidcStackProps extends cdk.StackProps {
  * Security recommendations followed:
  * - OIDC provider with thumbprint validation
  * - Role scoped to specific repository
- * - Role scoped to specific branch
+ * - Role scoped to specific GitHub environment
  * - Audience condition for sts.amazonaws.com
  */
 export class GitHubOidcStack extends cdk.Stack {

--- a/infra/lib/github-oidc-stack.ts
+++ b/infra/lib/github-oidc-stack.ts
@@ -90,13 +90,11 @@ export class GitHubOidcStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'RoleArn', {
       value: this.role.roleArn,
       description: 'ARN of the IAM role for GitHub Actions. Store this as a GitHub secret.',
-      exportName: 'GitHubActionsRoleArn',
     });
 
     new cdk.CfnOutput(this, 'OidcProviderArn', {
       value: githubOidcProvider.openIdConnectProviderArn,
       description: 'ARN of the GitHub OIDC provider',
-      exportName: 'GitHubOidcProviderArn',
     });
 
     // CDK Nag suppressions

--- a/infra/lib/github-oidc-stack.ts
+++ b/infra/lib/github-oidc-stack.ts
@@ -42,9 +42,6 @@ export class GitHubOidcStack extends cdk.Stack {
     const githubOidcProvider = new iam.OpenIdConnectProvider(this, 'GitHubOidcProvider', {
       url: 'https://token.actions.githubusercontent.com',
       clientIds: ['sts.amazonaws.com'],
-      // GitHub's thumbprint - this is stable and provided by GitHub
-      // See: https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/
-      thumbprints: ['ffffffffffffffffffffffffffffffffffffffff'],
     });
 
     this.role = new iam.Role(this, 'GitHubActionsRole', {

--- a/infra/lib/github-oidc-stack.ts
+++ b/infra/lib/github-oidc-stack.ts
@@ -1,0 +1,115 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+
+import * as iam from 'aws-cdk-lib/aws-iam';
+
+export interface GitHubOidcStackProps extends cdk.StackProps {
+  /**
+   * GitHub organization/owner name
+   */
+  readonly githubOrg: string;
+
+  /**
+   * GitHub repository name
+   */
+  readonly githubRepo: string;
+
+  /**
+   * Branch to allow deployments from (default: 'main')
+   */
+  readonly allowedBranch?: string;
+}
+
+/**
+ * Stack that creates GitHub OIDC provider and IAM role for GitHub Actions deployments.
+ * This is a one-time setup similar to CDK bootstrap.
+ *
+ * Security recommendations followed:
+ * - OIDC provider with thumbprint validation
+ * - Role scoped to specific repository
+ * - Role scoped to specific branch
+ * - Audience condition for sts.amazonaws.com
+ */
+export class GitHubOidcStack extends cdk.Stack {
+  public readonly role: iam.Role;
+  public readonly roleArn: string;
+
+  constructor(scope: Construct, id: string, props: GitHubOidcStackProps) {
+    super(scope, id, props);
+
+    const { githubOrg, githubRepo, allowedBranch = 'main' } = props;
+
+    // Step 1: Create OIDC Provider for GitHub
+    // GitHub's OIDC provider URL is fixed
+    const githubOidcProvider = new iam.OpenIdConnectProvider(this, 'GitHubOidcProvider', {
+      url: 'https://token.actions.githubusercontent.com',
+      clientIds: ['sts.amazonaws.com'],
+      // GitHub's thumbprint - this is stable and provided by GitHub
+      // See: https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/
+      thumbprints: ['ffffffffffffffffffffffffffffffffffffffff'],
+    });
+
+    // Step 2: Create IAM Role that trusts the OIDC provider
+    // Scoped down following security recommendations
+    this.role = new iam.Role(this, 'GitHubActionsRole', {
+      roleName: `GitHubActions-${githubRepo}`,
+      description: `Role for GitHub Actions deployments from ${githubOrg}/${githubRepo}`,
+      maxSessionDuration: cdk.Duration.hours(1),
+      assumedBy: new iam.FederatedPrincipal(
+        githubOidcProvider.openIdConnectProviderArn,
+        {
+          StringEquals: {
+            'token.actions.githubusercontent.com:aud': 'sts.amazonaws.com',
+          },
+          StringLike: {
+            // Scope to specific repo and branch
+            // Format: repo:<owner>/<repo>:ref:refs/heads/<branch>
+            'token.actions.githubusercontent.com:sub': `repo:${githubOrg}/${githubRepo}:ref:refs/heads/${allowedBranch}`,
+          },
+        },
+        'sts:AssumeRoleWithWebIdentity',
+      ),
+    });
+
+    // Permissions for CDK deployment
+    // This is a starting point - scope down further based on your needs
+    this.role.addToPolicy(
+      new iam.PolicyStatement({
+        sid: 'CDKDeploymentPermissions',
+        effect: iam.Effect.ALLOW,
+        actions: [
+          // CloudFormation permissions
+          'cloudformation:*',
+          // S3 for CDK assets
+          's3:*',
+          // SSM for CDK context lookups
+          'ssm:GetParameter',
+          // IAM for creating roles (CDK needs this)
+          'iam:*',
+          // Lambda for deploying functions
+          'lambda:*',
+          // Logs for Lambda
+          'logs:*',
+          // STS for assuming CDK roles
+          'sts:AssumeRole',
+        ],
+        resources: ['*'],
+      }),
+    );
+
+    this.roleArn = this.role.roleArn;
+
+    // Outputs
+    new cdk.CfnOutput(this, 'RoleArn', {
+      value: this.role.roleArn,
+      description: 'ARN of the IAM role for GitHub Actions. Store this as a GitHub secret.',
+      exportName: 'GitHubActionsRoleArn',
+    });
+
+    new cdk.CfnOutput(this, 'OidcProviderArn', {
+      value: githubOidcProvider.openIdConnectProviderArn,
+      description: 'ARN of the GitHub OIDC provider',
+      exportName: 'GitHubOidcProviderArn',
+    });
+  }
+}

--- a/infra/package.json
+++ b/infra/package.json
@@ -12,6 +12,8 @@
     "cdk": "cdk",
     "deploy": "npm run build && cdk deploy --require-approval never",
     "destroy": "cdk destroy",
+    "deploy:oidc": "tsc -p tsconfig.json && cdk deploy --app 'npx ts-node bin/github-oidc.ts' --require-approval never",
+    "synth:oidc": "tsc -p tsconfig.json && cdk synth --app 'npx ts-node bin/github-oidc.ts'",
     "prettier": "prettier . --write",
     "test": "npm run build && vitest run --coverage",
     "test:watch": "npm run build && vitest"

--- a/infra/package.json
+++ b/infra/package.json
@@ -13,6 +13,7 @@
     "deploy": "npm run build && cdk deploy --require-approval never",
     "destroy": "cdk destroy",
     "deploy:oidc": "tsc -p tsconfig.json && cdk deploy --app 'npx ts-node bin/github-oidc.ts' --require-approval never",
+    "destroy:oidc": "tsc -p tsconfig.json && cdk destroy --app 'npx ts-node bin/github-oidc.ts' --force",
     "synth:oidc": "tsc -p tsconfig.json && cdk synth --app 'npx ts-node bin/github-oidc.ts'",
     "prettier": "prettier . --write",
     "test": "npm run build && vitest run --coverage",

--- a/infra/test/github-oidc-stack.spec.ts
+++ b/infra/test/github-oidc-stack.spec.ts
@@ -1,0 +1,157 @@
+import { App } from 'aws-cdk-lib';
+import { describe, expect, it } from 'vitest';
+
+import { Template } from 'aws-cdk-lib/assertions';
+
+import { GitHubOidcStack } from '../lib/github-oidc-stack';
+
+function createOidcTestStack(environment: string) {
+  const app = new App();
+  const stack = new GitHubOidcStack(app, 'TestOidcStack', {
+    githubOrg: 'test-org',
+    githubRepo: 'test-repo',
+    environment,
+  });
+  const template = Template.fromStack(stack);
+  return { app, stack, template };
+}
+
+describe('GitHubOidcStack', () => {
+  describe('OIDC Provider', () => {
+    it('should create GitHub OIDC provider with correct URL', () => {
+      const { template } = createOidcTestStack('staging');
+
+      template.hasResourceProperties('Custom::AWSCDKOpenIdConnectProvider', {
+        Url: 'https://token.actions.githubusercontent.com',
+        ClientIDList: ['sts.amazonaws.com'],
+      });
+    });
+  });
+
+  describe('IAM Role', () => {
+    it('should create role with correct name pattern', () => {
+      const { template } = createOidcTestStack('staging');
+
+      template.hasResourceProperties('AWS::IAM::Role', {
+        RoleName: 'GitHubActions-test-repo',
+        MaxSessionDuration: 3600,
+      });
+    });
+
+    it('should scope trust policy to specific repo and environment', () => {
+      const { template } = createOidcTestStack('staging');
+
+      const roles = template.findResources('AWS::IAM::Role', {
+        Properties: {
+          RoleName: 'GitHubActions-test-repo',
+        },
+      });
+
+      const role = Object.values(roles)[0] as {
+        Properties: {
+          AssumeRolePolicyDocument: {
+            Statement: Array<{
+              Condition: {
+                StringEquals: Record<string, string>;
+                StringLike: Record<string, string>;
+              };
+            }>;
+          };
+        };
+      };
+
+      const statement = role.Properties.AssumeRolePolicyDocument.Statement[0];
+      expect(statement.Condition.StringEquals['token.actions.githubusercontent.com:aud']).toBe('sts.amazonaws.com');
+      expect(statement.Condition.StringLike['token.actions.githubusercontent.com:sub']).toBe('repo:test-org/test-repo:environment:staging');
+    });
+
+    it('should use prod environment in trust policy when specified', () => {
+      const { template } = createOidcTestStack('prod');
+
+      const roles = template.findResources('AWS::IAM::Role', {
+        Properties: {
+          RoleName: 'GitHubActions-test-repo',
+        },
+      });
+
+      const role = Object.values(roles)[0] as {
+        Properties: {
+          AssumeRolePolicyDocument: {
+            Statement: Array<{
+              Condition: {
+                StringLike: Record<string, string>;
+              };
+            }>;
+          };
+        };
+      };
+
+      const statement = role.Properties.AssumeRolePolicyDocument.Statement[0];
+      expect(statement.Condition.StringLike['token.actions.githubusercontent.com:sub']).toBe('repo:test-org/test-repo:environment:prod');
+    });
+  });
+
+  describe('IAM Policy', () => {
+    it('should only allow sts:AssumeRole action', () => {
+      const { template } = createOidcTestStack('staging');
+
+      const policies = template.findResources('AWS::IAM::Policy');
+      const policy = Object.values(policies)[0] as {
+        Properties: {
+          PolicyDocument: {
+            Statement: Array<{
+              Action: string;
+              Sid: string;
+            }>;
+          };
+        };
+      };
+
+      const statement = policy.Properties.PolicyDocument.Statement.find((s) => s.Sid === 'AssumeBootstrapRoles');
+      expect(statement).toBeDefined();
+      expect(statement!.Action).toBe('sts:AssumeRole');
+    });
+
+    it('should scope to CDK bootstrap roles only', () => {
+      const { template } = createOidcTestStack('staging');
+
+      const policies = template.findResources('AWS::IAM::Policy');
+      const policy = Object.values(policies)[0] as {
+        Properties: {
+          PolicyDocument: {
+            Statement: Array<{
+              Resource: unknown[];
+              Sid: string;
+            }>;
+          };
+        };
+      };
+
+      const statement = policy.Properties.PolicyDocument.Statement.find((s) => s.Sid === 'AssumeBootstrapRoles');
+      const resources = JSON.stringify(statement!.Resource);
+
+      expect(resources).toContain('cdk-*-deploy-role');
+      expect(resources).toContain('cdk-*-file-publishing-role');
+      expect(resources).toContain('cdk-*-image-publishing-role');
+      expect(resources).toContain('cdk-*-lookup-role');
+    });
+  });
+
+  describe('Stack Outputs', () => {
+    it('should output RoleArn', () => {
+      const { template } = createOidcTestStack('staging');
+
+      template.hasOutput('RoleArn', {
+        Description: 'ARN of the IAM role for GitHub Actions. Store this as a GitHub secret.',
+      });
+    });
+
+    it('should output OidcProviderArn', () => {
+      const { template } = createOidcTestStack('staging');
+
+      template.hasOutput('OidcProviderArn', {
+        Description: 'ARN of the GitHub OIDC provider',
+      });
+    });
+  });
+});


### PR DESCRIPTION
**Issue number:** closes #<replace with issue number>

## Summary

### Changes

Adds automated CDK deployment from GitHub Actions using OIDC authentication (no long-lived credentials).

- Created separate CDK stack (`GitHubOidcStack`) for OIDC provider and IAM role - deployed independently as a one-time setup
- Added deploy job to CI workflow with environment protection, concurrency controls, and SHA-pinned actions
- IAM role uses `sts:AssumeRole` to CDK bootstrap roles
- OIDC trust scoped to specific repository and GitHub environment

### User experience

Before: No deployment from pipeline

After: Merging to `main` automatically deploys to AWS via GitHub Actions with secure, credential-less authentication.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
