### PR TITLE
feat(evals): add agentcore online evaluation

### DIFF
--- a/.kiro/specs/agentcore-online-evals/design.md
+++ b/.kiro/specs/agentcore-online-evals/design.md
@@ -1,0 +1,429 @@
+# Design Document: AgentCore Online Evaluations
+
+## Overview
+
+This design describes a temporary CDK Custom Resource implementation for AgentCore Online Evaluations. The solution enables continuous evaluation of the agentic-cost-optimizer agent's performance using Bedrock AgentCore's built-in evaluators. Once the CDK L2 construct (`@aws-cdk/aws-bedrock-agentcore-alpha`) is published to npm, this implementation will be replaced.
+
+The implementation follows the existing project patterns and consists of:
+1. Configuration constants in `evals-config.ts`
+2. A CDK construct (`Evals`) that creates the execution role and Custom Resource
+3. A Python Lambda handler that calls the boto3 API
+4. Unit tests using vitest
+
+## Architecture
+
+```mermaid
+graph TB
+    subgraph "CDK Stack"
+        IS[InfraStack]
+        AC[Agent Construct]
+        EC[Evals Construct]
+        ER[Execution Role]
+        ACR[AwsCustomResource]
+    end
+    
+    subgraph "AWS Services"
+        CFN[CloudFormation]
+        BAC[Bedrock AgentCore Control]
+        CWL[CloudWatch Logs]
+        BR[Bedrock Models]
+    end
+    
+    IS --> AC
+    IS -->|enableEvals=true| EC
+    EC --> ER
+    EC --> ACR
+    
+    ACR -->|SDK calls| BAC
+    
+    BAC -->|reads traces| CWL
+    BAC -->|invokes for evaluation| BR
+    ER -.->|assumed by| BAC
+```
+
+Note: `AwsCustomResource` is a CDK construct that automatically creates a Lambda function to make AWS SDK calls. We don't need to write a separate Lambda handler.
+
+## Components and Interfaces
+
+### 1. Configuration Constants (`constants/evals-config.ts`)
+
+```typescript
+/**
+ * Configuration for AgentCore Online Evaluations
+ */
+export const EvalsConfig = {
+  /**
+   * Percentage of agent traces to sample for evaluation (0.01-100)
+   */
+  samplingPercentage: 100,
+
+  /**
+   * Minutes of inactivity after which a session is considered complete
+   */
+  sessionTimeoutMinutes: 5,
+
+  /**
+   * Built-in evaluators to apply during online evaluation
+   */
+  evaluators: [
+    'Builtin.ToolSelectionAccuracy',
+    'Builtin.ToolParameterAccuracy',
+    'Builtin.Correctness',
+    'Builtin.Helpfulness',
+    'Builtin.Conciseness',
+    'Builtin.InstructionFollowing',
+    'Builtin.ResponseRelevance',
+    'Builtin.Coherence',
+    'Builtin.Faithfulness',
+    'Builtin.GoalSuccessRate',
+  ],
+
+  /**
+   * Default endpoint name for AgentCore Runtime
+   */
+  defaultEndpointName: 'DEFAULT',
+} as const;
+
+/**
+ * Generate the evaluation config name based on environment
+ */
+export function getEvalsConfigName(environment: string): string {
+  return `cost_optimizer_eval_${environment}`;
+}
+```
+
+### 2. Evals Construct (`lib/evals.ts`)
+
+The `Evals` class is a CDK construct (similar to the existing `Agent` class in `lib/agent.ts`) that encapsulates all resources needed for online evaluations. It uses `cr.AwsCustomResource` from `aws-cdk-lib/custom-resources` which handles the Lambda creation, CloudFormation response handling, and SDK calls automatically. This is the same approach used in the L2 construct.
+
+```typescript
+import * as cr from 'aws-cdk-lib/custom-resources';
+
+export interface EvalsProps {
+  /**
+   * The Agent construct to evaluate
+   */
+  agent: Agent;
+
+  /**
+   * Environment name (used in config naming)
+   */
+  environment: string;
+}
+
+export class Evals extends Construct {
+  /**
+   * The execution role for the evaluation service
+   */
+  public readonly executionRole: iam.IRole;
+
+  /**
+   * The evaluation config ID (available after deployment)
+   */
+  public readonly configId: string;
+
+  /**
+   * The evaluation config ARN (available after deployment)
+   */
+  public readonly configArn: string;
+
+  constructor(scope: Construct, id: string, props: EvalsProps) {
+    // Creates execution role with required permissions
+    // Creates AwsCustomResource that calls bedrock-agentcore-control APIs
+  }
+}
+```
+
+The `AwsCustomResource` construct:
+- Automatically creates a Lambda function to make SDK calls
+- Handles CloudFormation response signaling
+- Supports onCreate, onUpdate, and onDelete handlers
+- Allows specifying IAM policies for the SDK calls
+```
+
+### 3. AwsCustomResource Configuration
+
+Since we're using `cr.AwsCustomResource`, we don't need a separate Lambda handler file. The construct handles SDK calls directly:
+
+```typescript
+const customResource = new cr.AwsCustomResource(this, 'Resource', {
+  resourceType: 'Custom::BedrockAgentCoreOnlineEvaluation',
+  installLatestAwsSdk: true,
+  onCreate: {
+    service: 'bedrock-agentcore-control',
+    action: 'CreateOnlineEvaluationConfig',
+    parameters: createParams,
+    physicalResourceId: cr.PhysicalResourceId.fromResponse('onlineEvaluationConfigId'),
+  },
+  onUpdate: {
+    service: 'bedrock-agentcore-control',
+    action: 'UpdateOnlineEvaluationConfig',
+    parameters: updateParams,
+    physicalResourceId: cr.PhysicalResourceId.fromResponse('onlineEvaluationConfigId'),
+  },
+  onDelete: {
+    service: 'bedrock-agentcore-control',
+    action: 'DeleteOnlineEvaluationConfig',
+    parameters: {
+      onlineEvaluationConfigId: new cr.PhysicalResourceIdReference(),
+    },
+  },
+  policy: cr.AwsCustomResourcePolicy.fromStatements([
+    // IAM permissions for SDK calls
+  ]),
+});
+```
+
+### 4. InfraStack Integration
+
+```typescript
+export interface InfraStackProps extends StackProps {
+  environment: string;
+  runtimeVersion: string;
+  enableManualTrigger: boolean;
+  /**
+   * Enable Online Evaluations for the agent
+   * @default - true only when environment === 'prod'
+   */
+  enableEvals?: boolean;
+}
+```
+
+## Data Models
+
+### Evaluation Config Request (Create)
+
+```typescript
+interface CreateOnlineEvaluationConfigRequest {
+  onlineEvaluationConfigName: string;
+  evaluators: Array<{ evaluatorId: string }>;
+  dataSourceConfig: {
+    cloudWatchLogs: {
+      logGroupNames: string[];
+      serviceNames: string[];
+    };
+  };
+  evaluationExecutionRoleArn: string;
+  enableOnCreate: boolean;
+  rule: {
+    samplingConfig: {
+      samplingPercentage: number;
+    };
+    sessionConfig: {
+      sessionTimeoutMinutes: number;
+    };
+  };
+  description?: string;
+}
+```
+
+### Evaluation Config Response
+
+```typescript
+interface OnlineEvaluationConfigResponse {
+  onlineEvaluationConfigId: string;
+  onlineEvaluationConfigArn: string;
+  status: string;
+  executionStatus: string;
+  createdAt: number;
+}
+```
+
+### Custom Resource Event
+
+```typescript
+interface CustomResourceEvent {
+  RequestType: 'Create' | 'Update' | 'Delete';
+  PhysicalResourceId?: string;
+  ResourceProperties: {
+    ServiceToken: string;
+    // All config passed via environment variables
+  };
+}
+```
+
+### Custom Resource Response
+
+```typescript
+interface CustomResourceResponse {
+  PhysicalResourceId: string;
+  Data: {
+    ConfigId: string;
+    ConfigArn: string;
+  };
+}
+```
+
+### IAM Permissions Model
+
+```typescript
+// Execution Role Trust Policy
+interface ExecutionRoleTrustPolicy {
+  principal: 'bedrock-agentcore.amazonaws.com';
+  conditions: {
+    'aws:SourceAccount': string;
+    'aws:ResourceAccount': string;
+    'aws:SourceArn': string[];  // evaluator/* and online-evaluation-config/*
+  };
+}
+
+// Execution Role Permissions
+interface ExecutionRolePermissions {
+  cloudWatchLogsRead: ['logs:DescribeLogGroups', 'logs:GetQueryResults', 'logs:StartQuery'];
+  cloudWatchLogsWrite: ['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents'];
+  cloudWatchIndexPolicy: ['logs:DescribeIndexPolicies', 'logs:PutIndexPolicy'];
+  bedrockModel: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream'];
+}
+
+// Custom Resource Lambda Permissions
+interface CustomResourceLambdaPermissions {
+  evaluationAdmin: [
+    'bedrock-agentcore:CreateOnlineEvaluationConfig',
+    'bedrock-agentcore:GetOnlineEvaluationConfig',
+    'bedrock-agentcore:UpdateOnlineEvaluationConfig',
+    'bedrock-agentcore:DeleteOnlineEvaluationConfig',
+    'bedrock-agentcore:ListOnlineEvaluationConfigs',
+  ];
+  passRole: ['iam:PassRole'];
+  cloudWatchIndex: ['logs:DescribeIndexPolicies', 'logs:PutIndexPolicy', 'logs:CreateLogGroup'];
+}
+```
+
+
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system—essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+Based on the prework analysis, the following properties can be tested:
+
+### Property 1: Default enableEvals based on environment
+
+*For any* environment string, when `enableEvals` is not explicitly specified, the default value SHALL be `true` if and only if `environment === 'prod'`.
+
+**Validates: Requirements 1.2**
+
+### Property 2: Config name pattern consistency
+
+*For any* valid environment string, the `getEvalsConfigName(environment)` function SHALL return a string matching the pattern `cost_optimizer_eval_{environment}`.
+
+**Validates: Requirements 2.3**
+
+### Property 3: Log group name derivation
+
+*For any* valid runtimeId and endpointName, the derived log group name SHALL match the pattern `/aws/bedrock-agentcore/runtimes/{runtimeId}-{endpointName}`.
+
+**Validates: Requirements 3.2**
+
+### Property 4: Service name derivation
+
+*For any* valid runtimeName and endpointName, the derived service name SHALL match the pattern `{runtimeName}.{endpointName}`.
+
+**Validates: Requirements 3.3**
+
+### Property Reflection
+
+After reviewing the testable properties:
+- Properties 2, 3, and 4 are string formatting properties that can be combined conceptually but test different functions
+- Property 1 tests conditional logic based on environment
+- Most other acceptance criteria are example-based tests (specific CDK template assertions) rather than properties
+
+The remaining acceptance criteria (IAM permissions, resource creation, Lambda behavior) are better suited for example-based unit tests using CDK template assertions and mocking, as they verify specific configurations rather than universal properties.
+
+## Error Handling
+
+### AwsCustomResource Error Handling
+
+The `AwsCustomResource` construct handles errors automatically:
+- SDK errors are caught and reported to CloudFormation as FAILED
+- The error message is included in the CloudFormation event
+- Stack rollback is triggered on failure
+
+### Error Scenarios
+
+| Scenario | Handling |
+|----------|----------|
+| Invalid config name | SDK raises ValidationException, CloudFormation marks FAILED |
+| Missing execution role | SDK raises AccessDeniedException, CloudFormation marks FAILED |
+| Config already exists | SDK raises ConflictException, CloudFormation marks FAILED |
+| Config not found (Delete) | SDK may raise ResourceNotFoundException, handled gracefully |
+| Network timeout | SDK raises timeout error, CloudFormation marks FAILED |
+
+### CDK Construct Error Handling
+
+- If Agent construct is not provided, TypeScript compilation fails
+- If environment is not provided, TypeScript compilation fails
+- Invalid IAM policy statements are caught by CDK synthesis
+
+## Testing Strategy
+
+### Dual Testing Approach
+
+This feature uses both unit tests and property-based tests:
+
+1. **Unit Tests (vitest)**: Verify specific CDK template assertions and Lambda behavior
+2. **Property Tests (fast-check)**: Verify universal properties across all inputs
+
+### Unit Test Coverage
+
+| Test Case | Requirement | Type |
+|-----------|-------------|------|
+| Evals construct creates Custom Resource when enabled | 1.3 | Example |
+| Evals construct does NOT create resources when disabled | 1.4 | Example |
+| Config constants have correct values | 2.1, 2.2, 2.4 | Example |
+| Execution role has correct trust policy | 4.1, 4.2 | Example |
+| Execution role has CloudWatch Logs read permissions | 4.3 | Example |
+| Execution role has CloudWatch Logs write permissions | 4.4 | Example |
+| Execution role has CloudWatch index policy permissions | 4.5 | Example |
+| Execution role has Bedrock model permissions | 4.6 | Example |
+| Custom Resource Lambda role has admin permissions | 5.8 | Example |
+| Custom Resource Lambda role has PassRole permission | 5.9 | Example |
+| Custom Resource Lambda role has index policy permissions | 5.10 | Example |
+
+### Property Test Coverage
+
+| Property | Requirement | Iterations |
+|----------|-------------|------------|
+| Default enableEvals based on environment | 1.2 | 100 |
+| Config name pattern consistency | 2.3 | 100 |
+| Log group name derivation | 3.2 | 100 |
+| Service name derivation | 3.3 | 100 |
+
+### Test File Structure
+
+```
+agentic-cost-optimizer/infra/test/
+├── setup.ts                    # Existing test setup
+├── evals.spec.ts               # New: Evals construct tests
+└── evals-config.spec.ts        # New: Config constants tests
+```
+
+### Property Test Configuration
+
+- Library: fast-check (already available in Node.js ecosystem)
+- Minimum iterations: 100 per property
+- Tag format: `Feature: agentcore-online-evals, Property N: {property_text}`
+
+### Example Property Test
+
+```typescript
+import * as fc from 'fast-check';
+import { describe, it, expect } from 'vitest';
+import { getEvalsConfigName } from '../constants/evals-config';
+
+describe('Evals Config Properties', () => {
+  // Feature: agentcore-online-evals, Property 2: Config name pattern consistency
+  it('should generate config name matching pattern for any environment', () => {
+    fc.assert(
+      fc.property(
+        fc.stringOf(fc.constantFrom(...'abcdefghijklmnopqrstuvwxyz0123456789_'), { minLength: 1, maxLength: 20 }),
+        (environment) => {
+          const result = getEvalsConfigName(environment);
+          expect(result).toBe(`cost_optimizer_eval_${environment}`);
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+});
+```

--- a/.kiro/specs/agentcore-online-evals/requirements.md
+++ b/.kiro/specs/agentcore-online-evals/requirements.md
@@ -1,0 +1,108 @@
+# Requirements Document
+
+## Introduction
+
+This feature adds AgentCore Online Evaluations to the agentic-cost-optimizer project using a CDK Custom Resource. Since the CDK L2 construct (`@aws-cdk/aws-bedrock-agentcore-alpha`) is not yet published to npm, this is a temporary implementation that calls the boto3 API directly via a Lambda-backed Custom Resource. The implementation will be replaced by the L2 construct once it becomes available.
+
+## Glossary
+
+- **Evals_Construct**: The CDK construct that creates and manages the Online Evaluation configuration via AwsCustomResource
+- **AwsCustomResource**: The CDK construct from `aws-cdk-lib/custom-resources` that handles CloudFormation Custom Resource lifecycle and SDK calls automatically
+- **Execution_Role**: The IAM role assumed by the Bedrock AgentCore service to perform evaluations
+- **Online_Evaluation_Config**: The Bedrock AgentCore configuration that defines which evaluators to run and how to sample agent traces
+- **Evaluator**: A built-in assessment module that evaluates specific aspects of agent performance (e.g., CORRECTNESS, HELPFULNESS)
+- **Data_Source_Config**: The CloudWatch Logs configuration specifying where to read agent traces from, containing `logGroupNames` and `serviceNames` derived from the AgentCore Runtime
+- **Runtime_Id**: The unique identifier of the AgentCore Runtime (e.g., `agentRuntime_dev_v2-Fgmi5R78OC`)
+- **Runtime_Name**: The name of the AgentCore Runtime (e.g., `agentRuntime_dev_v2`)
+- **Endpoint_Name**: The name of the runtime endpoint, defaults to `DEFAULT`
+- **Sampling_Percentage**: The percentage of agent traces to evaluate (0.01-100)
+- **Session_Timeout**: Minutes of inactivity after which an agent session is considered complete
+
+## Requirements
+
+### Requirement 1: Deployment Control
+
+**User Story:** As a developer, I want to control when Online Evaluations are deployed, so that I can enable them only in production by default while allowing override for testing.
+
+#### Acceptance Criteria
+
+1. THE Infra_Stack SHALL accept an `enableEvals` boolean property
+2. WHEN `enableEvals` is not specified, THE Infra_Stack SHALL default to `true` only when `environment === 'prod'`
+3. WHEN `enableEvals` is `true`, THE Infra_Stack SHALL create the Evals_Construct
+4. WHEN `enableEvals` is `false`, THE Infra_Stack SHALL NOT create the Evals_Construct
+5. THE bin/infra.ts SHALL pass `enableEvals` to InfraStack based on environment with override capability
+
+### Requirement 2: Configuration Constants
+
+**User Story:** As a developer, I want evaluation configuration centralized in a constants file, so that I can easily modify settings without changing construct code.
+
+#### Acceptance Criteria
+
+1. THE evals-config.ts SHALL define a `samplingPercentage` constant with default value `100`
+2. THE evals-config.ts SHALL define a `sessionTimeoutMinutes` constant with default value `5`
+3. THE evals-config.ts SHALL define a `configNamePattern` function that returns `cost_optimizer_eval_{environment}`
+4. THE evals-config.ts SHALL define an array of 10 built-in evaluator identifiers:
+   - `Builtin.ToolSelectionAccuracy`
+   - `Builtin.ToolParameterAccuracy`
+   - `Builtin.Correctness`
+   - `Builtin.Helpfulness`
+   - `Builtin.Conciseness`
+   - `Builtin.InstructionFollowing`
+   - `Builtin.ResponseRelevance`
+   - `Builtin.Coherence`
+   - `Builtin.Faithfulness`
+   - `Builtin.GoalSuccessRate`
+5. THE evals-config.ts SHALL export all constants for use by the Evals_Construct
+
+### Requirement 3: Evals Construct
+
+**User Story:** As a developer, I want a CDK construct that creates Online Evaluation configurations, so that I can deploy evaluations as infrastructure-as-code.
+
+#### Acceptance Criteria
+
+1. THE Evals_Construct SHALL accept the Agent construct as a required property to derive runtime details
+2. THE Evals_Construct SHALL derive the log group name using pattern `/aws/bedrock-agentcore/runtimes/{runtimeId}-{endpointName}` where `endpointName` defaults to `DEFAULT`
+3. THE Evals_Construct SHALL derive the service name using pattern `{runtimeName}.{endpointName}` where `endpointName` defaults to `DEFAULT`
+4. THE Evals_Construct SHALL create an Execution_Role with the required IAM permissions
+5. THE Evals_Construct SHALL create an AwsCustomResource to manage the evaluation config via SDK calls
+6. THE AwsCustomResource SHALL call `CreateOnlineEvaluationConfig` on create
+7. THE AwsCustomResource SHALL call `UpdateOnlineEvaluationConfig` on update
+8. THE AwsCustomResource SHALL call `DeleteOnlineEvaluationConfig` on delete
+9. THE Evals_Construct SHALL output the evaluation config ID and ARN as CloudFormation outputs
+
+### Requirement 4: Execution Role Permissions
+
+**User Story:** As a security-conscious developer, I want the execution role to have minimal required permissions, so that the evaluation service operates with least privilege.
+
+#### Acceptance Criteria
+
+1. THE Execution_Role SHALL have a trust policy allowing `bedrock-agentcore.amazonaws.com` to assume it
+2. THE Execution_Role trust policy SHALL include conditions for `aws:SourceAccount` and `aws:ResourceAccount`
+3. THE Execution_Role SHALL have CloudWatch Logs read permissions: `logs:DescribeLogGroups`, `logs:GetQueryResults`, `logs:StartQuery`
+4. THE Execution_Role SHALL have CloudWatch Logs write permissions for `/aws/bedrock-agentcore/evaluations/*`: `logs:CreateLogGroup`, `logs:CreateLogStream`, `logs:PutLogEvents`
+5. THE Execution_Role SHALL have CloudWatch index policy permissions for `aws/spans`: `logs:DescribeIndexPolicies`, `logs:PutIndexPolicy`
+6. THE Execution_Role SHALL have Bedrock model invocation permissions: `bedrock:InvokeModel`, `bedrock:InvokeModelWithResponseStream`
+
+### Requirement 5: AwsCustomResource Permissions
+
+**User Story:** As a developer, I want the AwsCustomResource to have the correct IAM permissions, so that it can manage evaluation configs via SDK calls.
+
+#### Acceptance Criteria
+
+1. THE AwsCustomResource policy SHALL have permissions to manage evaluation configs: `bedrock-agentcore:CreateOnlineEvaluationConfig`, `bedrock-agentcore:GetOnlineEvaluationConfig`, `bedrock-agentcore:UpdateOnlineEvaluationConfig`, `bedrock-agentcore:DeleteOnlineEvaluationConfig`, `bedrock-agentcore:ListOnlineEvaluationConfigs`
+2. THE AwsCustomResource policy SHALL have `iam:PassRole` permission for the Execution_Role
+3. THE AwsCustomResource policy SHALL have CloudWatch index policy permissions: `logs:DescribeIndexPolicies`, `logs:PutIndexPolicy`, `logs:CreateLogGroup`
+
+### Requirement 6: Unit Tests
+
+**User Story:** As a developer, I want comprehensive unit tests, so that I can verify the construct behaves correctly.
+
+#### Acceptance Criteria
+
+1. THE test suite SHALL verify the Evals_Construct creates an AwsCustomResource when enabled
+2. THE test suite SHALL verify the Evals_Construct does NOT create resources when disabled
+3. THE test suite SHALL verify the Execution_Role has the correct trust policy
+4. THE test suite SHALL verify the Execution_Role has CloudWatch Logs read permissions
+5. THE test suite SHALL verify the Execution_Role has CloudWatch Logs write permissions
+6. THE test suite SHALL verify the Execution_Role has Bedrock model invocation permissions
+7. THE test suite SHALL follow existing test patterns using vitest

--- a/.kiro/specs/agentcore-online-evals/tasks.md
+++ b/.kiro/specs/agentcore-online-evals/tasks.md
@@ -1,0 +1,119 @@
+# Implementation Plan: AgentCore Online Evaluations
+
+## Overview
+
+This implementation plan follows a proper feature development lifecycle:
+1. Create code in logical chunks
+2. Test each chunk when possible
+3. Commit after each logical phase
+4. Deploy to dev when ready
+
+The implementation uses TypeScript for CDK constructs and vitest for testing. No Python Lambda code is needed since we use `AwsCustomResource`.
+
+## Tasks
+
+- [ ] 1. Create configuration constants
+  - [ ] 1.1 Create `constants/evals-config.ts` with evaluation configuration
+    - Define `samplingPercentage` (100)
+    - Define `sessionTimeoutMinutes` (5)
+    - Define `evaluators` array with 10 built-in evaluators
+    - Define `defaultEndpointName` ('DEFAULT')
+    - Export `getEvalsConfigName(environment)` function
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5_
+
+  - [ ]* 1.2 Write unit tests for evals-config
+    - Test `getEvalsConfigName` returns correct pattern
+    - Test constants have expected values
+    - _Requirements: 2.1, 2.2, 2.3, 2.4_
+
+- [ ] 2. Checkpoint - Run tests and commit
+  - Run `npm test` to verify config tests pass
+  - Commit: "feat(evals): add evaluation configuration constants"
+
+- [ ] 3. Create Evals construct
+  - [ ] 3.1 Create `lib/evals.ts` with Evals construct class
+    - Define `EvalsProps` interface accepting Agent and environment
+    - Create execution role with trust policy for `bedrock-agentcore.amazonaws.com`
+    - Add CloudWatch Logs read permissions to execution role
+    - Add CloudWatch Logs write permissions for `/aws/bedrock-agentcore/evaluations/*`
+    - Add CloudWatch index policy permissions for `aws/spans`
+    - Add Bedrock model invocation permissions
+    - _Requirements: 3.1, 3.4, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6_
+
+  - [ ] 3.2 Add AwsCustomResource to Evals construct
+    - Derive log group name from Agent runtime: `/aws/bedrock-agentcore/runtimes/{runtimeId}-DEFAULT`
+    - Derive service name from Agent runtime: `{runtimeName}.DEFAULT`
+    - Create AwsCustomResource with onCreate/onUpdate/onDelete handlers
+    - Add policy for bedrock-agentcore admin permissions
+    - Add policy for iam:PassRole
+    - Add policy for CloudWatch index permissions
+    - Export configId and configArn from custom resource response
+    - _Requirements: 3.2, 3.3, 3.5, 3.6, 3.7, 3.8, 3.9, 5.1, 5.2, 5.3_
+
+  - [ ] 3.3 Add CDK Nag suppressions to Evals construct
+    - Suppress wildcard warnings with appropriate justifications
+    - Follow existing patterns from Agent construct
+    - _Requirements: 3.4_
+
+  - [ ]* 3.4 Write unit tests for Evals construct
+    - Test execution role has correct trust policy
+    - Test execution role has CloudWatch Logs read permissions
+    - Test execution role has CloudWatch Logs write permissions
+    - Test execution role has CloudWatch index policy permissions
+    - Test execution role has Bedrock model permissions
+    - Test AwsCustomResource is created with correct service/action
+    - Test AwsCustomResource policy has admin permissions
+    - Test AwsCustomResource policy has PassRole permission
+    - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 5.1, 5.2, 5.3, 6.1, 6.3, 6.4, 6.5, 6.6_
+
+- [ ] 4. Checkpoint - Run tests and commit
+  - Run `npm test` to verify Evals construct tests pass
+  - Commit: "feat(evals): add Evals construct with AwsCustomResource"
+
+- [ ] 5. Integrate Evals into InfraStack
+  - [ ] 5.1 Update `lib/infra-stack.ts` to add enableEvals prop
+    - Add `enableEvals?: boolean` to InfraStackProps
+    - Conditionally create Evals construct when enableEvals is true
+    - Add CfnOutputs for evaluation config ID and ARN
+    - _Requirements: 1.1, 1.3, 1.4_
+
+  - [ ] 5.2 Update `bin/infra.ts` to pass enableEvals
+    - Default enableEvals to `environment === 'prod'`
+    - Allow override via environment variable or context
+    - _Requirements: 1.2, 1.5_
+
+  - [ ]* 5.3 Write unit tests for conditional Evals creation
+    - Test Evals construct is created when enableEvals=true
+    - Test Evals construct is NOT created when enableEvals=false
+    - Test default enableEvals behavior based on environment
+    - _Requirements: 1.2, 1.3, 1.4, 6.1, 6.2_
+
+- [ ] 6. Checkpoint - Run all tests and commit
+  - Run `npm test` to verify all tests pass
+  - Run `npm run lint` to verify code style
+  - Commit: "feat(evals): integrate Evals construct into InfraStack"
+
+- [ ] 7. Final verification
+  - [ ] 7.1 Run CDK synth to verify template generation
+    - Run `npx cdk synth` with enableEvals=true
+    - Verify Custom Resource is in template
+    - Verify IAM roles and policies are correct
+    - _Requirements: All_
+
+  - [ ] 7.2 Update README if needed
+    - Document enableEvals prop
+    - Document how to enable/disable evaluations
+    - _Requirements: Documentation_
+
+- [ ] 8. Deploy to dev environment
+  - Run `npx cdk deploy` with enableEvals=true in dev
+  - Verify evaluation config is created in AWS console
+  - Verify no deployment errors
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each checkpoint includes running tests and committing
+- The implementation follows existing patterns from the Agent construct
+- Property tests use fast-check library (install if not present)
+- All tests use vitest following existing project patterns

--- a/.kiro/specs/agentcore-online-evals/tasks.md
+++ b/.kiro/specs/agentcore-online-evals/tasks.md
@@ -12,8 +12,8 @@ The implementation uses TypeScript for CDK constructs and vitest for testing. No
 
 ## Tasks
 
-- [ ] 1. Create configuration constants
-  - [ ] 1.1 Create `constants/evals-config.ts` with evaluation configuration
+- [-] 1. Create configuration constants
+  - [x] 1.1 Create `constants/evals-config.ts` with evaluation configuration
     - Define `samplingPercentage` (100)
     - Define `sessionTimeoutMinutes` (5)
     - Define `evaluators` array with 10 built-in evaluators
@@ -21,13 +21,13 @@ The implementation uses TypeScript for CDK constructs and vitest for testing. No
     - Export `getEvalsConfigName(environment)` function
     - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5_
 
-  - [ ]* 1.2 Write unit tests for evals-config
+  - [x] 1.2 Write unit tests for evals-config
     - Test `getEvalsConfigName` returns correct pattern
     - Test constants have expected values
     - _Requirements: 2.1, 2.2, 2.3, 2.4_
 
-- [ ] 2. Checkpoint - Run tests and commit
-  - Run `npm test` to verify config tests pass
+- [x] 2. Checkpoint - Run tests and commit
+  - Run `make test` to verify config tests pass
   - Commit: "feat(evals): add evaluation configuration constants"
 
 - [ ] 3. Create Evals construct
@@ -67,7 +67,7 @@ The implementation uses TypeScript for CDK constructs and vitest for testing. No
     - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 5.1, 5.2, 5.3, 6.1, 6.3, 6.4, 6.5, 6.6_
 
 - [ ] 4. Checkpoint - Run tests and commit
-  - Run `npm test` to verify Evals construct tests pass
+  - Run `make test` to verify Evals construct tests pass
   - Commit: "feat(evals): add Evals construct with AwsCustomResource"
 
 - [ ] 5. Integrate Evals into InfraStack
@@ -89,8 +89,8 @@ The implementation uses TypeScript for CDK constructs and vitest for testing. No
     - _Requirements: 1.2, 1.3, 1.4, 6.1, 6.2_
 
 - [ ] 6. Checkpoint - Run all tests and commit
-  - Run `npm test` to verify all tests pass
-  - Run `npm run lint` to verify code style
+  - Run `make test` to verify all tests pass
+  - Run `make check` to verify code style
   - Commit: "feat(evals): integrate Evals construct into InfraStack"
 
 - [ ] 7. Final verification

--- a/.kiro/specs/agentcore-online-evals/tasks.md
+++ b/.kiro/specs/agentcore-online-evals/tasks.md
@@ -30,8 +30,8 @@ The implementation uses TypeScript for CDK constructs and vitest for testing. No
   - Run `make test` to verify config tests pass
   - Commit: "feat(evals): add evaluation configuration constants"
 
-- [ ] 3. Create Evals construct
-  - [ ] 3.1 Create `lib/evals.ts` with Evals construct class
+- [x] 3. Create Evals construct
+  - [x] 3.1 Create `lib/evals.ts` with Evals construct class
     - Define `EvalsProps` interface accepting Agent and environment
     - Create execution role with trust policy for `bedrock-agentcore.amazonaws.com`
     - Add CloudWatch Logs read permissions to execution role
@@ -40,7 +40,7 @@ The implementation uses TypeScript for CDK constructs and vitest for testing. No
     - Add Bedrock model invocation permissions
     - _Requirements: 3.1, 3.4, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6_
 
-  - [ ] 3.2 Add AwsCustomResource to Evals construct
+  - [x] 3.2 Add AwsCustomResource to Evals construct
     - Derive log group name from Agent runtime: `/aws/bedrock-agentcore/runtimes/{runtimeId}-DEFAULT`
     - Derive service name from Agent runtime: `{runtimeName}.DEFAULT`
     - Create AwsCustomResource with onCreate/onUpdate/onDelete handlers
@@ -50,12 +50,12 @@ The implementation uses TypeScript for CDK constructs and vitest for testing. No
     - Export configId and configArn from custom resource response
     - _Requirements: 3.2, 3.3, 3.5, 3.6, 3.7, 3.8, 3.9, 5.1, 5.2, 5.3_
 
-  - [ ] 3.3 Add CDK Nag suppressions to Evals construct
+  - [x] 3.3 Add CDK Nag suppressions to Evals construct
     - Suppress wildcard warnings with appropriate justifications
     - Follow existing patterns from Agent construct
     - _Requirements: 3.4_
 
-  - [ ]* 3.4 Write unit tests for Evals construct
+  - [x] 3.4 Write unit tests for Evals construct
     - Test execution role has correct trust policy
     - Test execution role has CloudWatch Logs read permissions
     - Test execution role has CloudWatch Logs write permissions
@@ -66,7 +66,7 @@ The implementation uses TypeScript for CDK constructs and vitest for testing. No
     - Test AwsCustomResource policy has PassRole permission
     - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 5.1, 5.2, 5.3, 6.1, 6.3, 6.4, 6.5, 6.6_
 
-- [ ] 4. Checkpoint - Run tests and commit
+- [-] 4. Checkpoint - Run tests and commit
   - Run `make test` to verify Evals construct tests pass
   - Commit: "feat(evals): add Evals construct with AwsCustomResource"
 

--- a/.kiro/specs/agentcore-online-evals/tasks.md
+++ b/.kiro/specs/agentcore-online-evals/tasks.md
@@ -66,29 +66,29 @@ The implementation uses TypeScript for CDK constructs and vitest for testing. No
     - Test AwsCustomResource policy has PassRole permission
     - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 5.1, 5.2, 5.3, 6.1, 6.3, 6.4, 6.5, 6.6_
 
-- [-] 4. Checkpoint - Run tests and commit
+- [x] 4. Checkpoint - Run tests and commit
   - Run `make test` to verify Evals construct tests pass
   - Commit: "feat(evals): add Evals construct with AwsCustomResource"
 
-- [ ] 5. Integrate Evals into InfraStack
-  - [ ] 5.1 Update `lib/infra-stack.ts` to add enableEvals prop
+- [x] 5. Integrate Evals into InfraStack
+  - [x] 5.1 Update `lib/infra-stack.ts` to add enableEvals prop
     - Add `enableEvals?: boolean` to InfraStackProps
     - Conditionally create Evals construct when enableEvals is true
     - Add CfnOutputs for evaluation config ID and ARN
     - _Requirements: 1.1, 1.3, 1.4_
 
-  - [ ] 5.2 Update `bin/infra.ts` to pass enableEvals
+  - [x] 5.2 Update `bin/infra.ts` to pass enableEvals
     - Default enableEvals to `environment === 'prod'`
     - Allow override via environment variable or context
     - _Requirements: 1.2, 1.5_
 
-  - [ ]* 5.3 Write unit tests for conditional Evals creation
+  - [x] 5.3 Write unit tests for conditional Evals creation
     - Test Evals construct is created when enableEvals=true
     - Test Evals construct is NOT created when enableEvals=false
     - Test default enableEvals behavior based on environment
     - _Requirements: 1.2, 1.3, 1.4, 6.1, 6.2_
 
-- [ ] 6. Checkpoint - Run all tests and commit
+- [x] 6. Checkpoint - Run all tests and commit
   - Run `make test` to verify all tests pass
   - Run `make check` to verify code style
   - Commit: "feat(evals): integrate Evals construct into InfraStack"

--- a/.kiro/specs/agentcore-online-evals/tasks.md
+++ b/.kiro/specs/agentcore-online-evals/tasks.md
@@ -93,19 +93,19 @@ The implementation uses TypeScript for CDK constructs and vitest for testing. No
   - Run `make check` to verify code style
   - Commit: "feat(evals): integrate Evals construct into InfraStack"
 
-- [ ] 7. Final verification
-  - [ ] 7.1 Run CDK synth to verify template generation
+- [x] 7. Final verification
+  - [x] 7.1 Run CDK synth to verify template generation
     - Run `npx cdk synth` with enableEvals=true
     - Verify Custom Resource is in template
     - Verify IAM roles and policies are correct
     - _Requirements: All_
 
-  - [ ] 7.2 Update README if needed
+  - [x] 7.2 Update README if needed
     - Document enableEvals prop
     - Document how to enable/disable evaluations
     - _Requirements: Documentation_
 
-- [ ] 8. Deploy to dev environment
+- [x] 8. Deploy to dev environment
   - Run `npx cdk deploy` with enableEvals=true in dev
   - Verify evaluation config is created in AWS console
   - Verify no deployment errors

--- a/README.md
+++ b/README.md
@@ -96,10 +96,32 @@ The agent will analyze your AWS Lambda functions and save a cost optimization re
 
 Set these environment variables (or use defaults):
 
-- `ENVIRONMENT`: Environment name (default: `dev`)
-- `VERSION`: Version tag (default: `v1`)
-- `MODEL_ID`: Amazon Bedrock model ID (default: Claude Sonnet 4)
-- `TTL_DAYS`: Amazon DynamoDB record retention (default: `30`)
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `ENVIRONMENT` | Environment name (`dev`, `staging`, `prod`) | `dev` |
+| `RUNTIME_VERSION` | Version suffix for runtime naming | `v2` |
+| `MODEL_ID` | Amazon Bedrock model ID | Claude Sonnet 4 |
+| `TTL_DAYS` | Amazon DynamoDB record retention | `30` |
+| `ENABLE_EVALS` | Enable Online Evaluations | `true` in prod only |
+
+### Environment-Based Features
+
+| Feature | dev | staging | prod |
+|---------|-----|---------|------|
+| Online Evaluations | ❌ | ❌ | ✅ |
+| Manual Trigger | ✅ | ❌ | ❌ |
+
+**Deploy to production:**
+```bash
+ENVIRONMENT=prod make cdk-deploy
+```
+
+**Override evals (e.g., enable in dev for testing):**
+```bash
+ENVIRONMENT=dev ENABLE_EVALS=true make cdk-deploy
+```
+
+For more on Online Evaluations, see the [AgentCore Evaluations documentation](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/evaluations.html).
 
 ## Deployment
 

--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -9,11 +9,22 @@ const app = new cdk.App();
 const environment = process.env.ENVIRONMENT || 'dev';
 const runtimeVersion = process.env.RUNTIME_VERSION || 'v2';
 
+// Enable evals: default to true only for prod, allow override via env var or context
+const enableEvalsEnv = process.env.ENABLE_EVALS;
+const enableEvalsContext = app.node.tryGetContext('enableEvals');
+const enableEvals =
+  enableEvalsEnv !== undefined
+    ? enableEvalsEnv === 'true'
+    : enableEvalsContext !== undefined
+      ? enableEvalsContext === true || enableEvalsContext === 'true'
+      : environment === 'prod';
+
 new InfraStack(app, 'InfraStack', {
   description: InfraConfig.stackDescription,
   environment,
   runtimeVersion,
   enableManualTrigger: environment === 'dev',
+  enableEvals,
 });
 
 cdk.Aspects.of(app).add(new AwsSolutionsChecks({ verbose: true }));

--- a/infra/constants/evals-config.ts
+++ b/infra/constants/evals-config.ts
@@ -1,0 +1,42 @@
+/**
+ * Configuration for AgentCore Online Evaluations
+ */
+export const EvalsConfig = {
+  /**
+   * Percentage of agent traces to sample for evaluation (0.01-100)
+   */
+  samplingPercentage: 100,
+
+  /**
+   * Minutes of inactivity after which a session is considered complete
+   */
+  sessionTimeoutMinutes: 5,
+
+  /**
+   * Built-in evaluators to apply during online evaluation
+   */
+  evaluators: [
+    'Builtin.ToolSelectionAccuracy',
+    'Builtin.ToolParameterAccuracy',
+    'Builtin.Correctness',
+    'Builtin.Helpfulness',
+    'Builtin.Conciseness',
+    'Builtin.InstructionFollowing',
+    'Builtin.ResponseRelevance',
+    'Builtin.Coherence',
+    'Builtin.Faithfulness',
+    'Builtin.GoalSuccessRate',
+  ],
+
+  /**
+   * Default endpoint name for AgentCore Runtime
+   */
+  defaultEndpointName: 'DEFAULT',
+} as const;
+
+/**
+ * Generate the evaluation config name based on environment
+ */
+export function getEvalsConfigName(environment: string): string {
+  return `cost_optimizer_eval_${environment}`;
+}

--- a/infra/lib/agent.ts
+++ b/infra/lib/agent.ts
@@ -41,6 +41,7 @@ export interface AgentProps {
 export class Agent extends Construct {
   public readonly runtime: Runtime;
   public readonly runtimeArn: string;
+  public readonly runtimeName: string;
 
   constructor(scope: Construct, id: string, props: AgentProps) {
     super(scope, id);
@@ -146,6 +147,7 @@ export class Agent extends Construct {
     monitoringPolicy.attachToRole(this.runtime.role);
 
     this.runtimeArn = this.runtime.agentRuntimeArn;
+    this.runtimeName = agentRuntimeName;
 
     this.applyNagSuppressions(bedrockPolicy, monitoringPolicy);
   }

--- a/infra/lib/evals.ts
+++ b/infra/lib/evals.ts
@@ -1,0 +1,222 @@
+import { Stack } from 'aws-cdk-lib';
+import { NagSuppressions } from 'cdk-nag';
+import { Construct } from 'constructs';
+
+import { Effect, PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { AwsCustomResource, AwsCustomResourcePolicy, PhysicalResourceId, PhysicalResourceIdReference } from 'aws-cdk-lib/custom-resources';
+
+import { EvalsConfig, getEvalsConfigName } from '../constants/evals-config';
+import { Agent } from './agent';
+
+export interface EvalsProps {
+  /**
+   * The Agent construct to evaluate
+   */
+  agent: Agent;
+
+  /**
+   * Environment name (used in config naming)
+   */
+  environment: string;
+}
+
+/**
+ * CDK construct that creates an AgentCore Online Evaluation configuration.
+ *
+ * This is a temporary implementation using AwsCustomResource to call the
+ * bedrock-agentcore-control API directly. It will be replaced by the L2
+ * construct once @aws-cdk/aws-bedrock-agentcore-alpha is published.
+ */
+export class Evals extends Construct {
+  public readonly executionRole: Role;
+  public readonly configId: string;
+  public readonly configArn: string;
+
+  constructor(scope: Construct, id: string, props: EvalsProps) {
+    super(scope, id);
+
+    const { agent, environment } = props;
+    const stack = Stack.of(this);
+
+    const agentRuntimeId = agent.runtime.agentRuntimeId;
+    const agentRuntimeName = agent.runtimeName;
+    const runtimeEndpointName = EvalsConfig.defaultEndpointName;
+
+    // CloudWatch Logs data source derived from Agent runtime
+    const traceLogGroupName = `/aws/bedrock-agentcore/runtimes/${agentRuntimeId}-${runtimeEndpointName}`;
+    const traceServiceName = `${agentRuntimeName}.${runtimeEndpointName}`;
+
+    this.executionRole = new Role(this, 'ExecutionRole', {
+      assumedBy: new ServicePrincipal('bedrock-agentcore.amazonaws.com', {
+        conditions: {
+          StringEquals: {
+            'aws:SourceAccount': stack.account,
+            'aws:ResourceAccount': stack.account,
+          },
+          ArnLike: {
+            'aws:SourceArn': [
+              `arn:${stack.partition}:bedrock-agentcore:${stack.region}:${stack.account}:evaluator/*`,
+              `arn:${stack.partition}:bedrock-agentcore:${stack.region}:${stack.account}:online-evaluation-config/*`,
+            ],
+          },
+        },
+      }),
+      description: 'Execution role for AgentCore Online Evaluations',
+    });
+
+    this.executionRole.addToPolicy(
+      new PolicyStatement({
+        sid: 'CloudWatchLogsRead',
+        effect: Effect.ALLOW,
+        actions: ['logs:DescribeLogGroups', 'logs:GetQueryResults', 'logs:StartQuery'],
+        resources: ['*'],
+      }),
+    );
+
+    this.executionRole.addToPolicy(
+      new PolicyStatement({
+        sid: 'CloudWatchLogsWrite',
+        effect: Effect.ALLOW,
+        actions: ['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents'],
+        resources: [`arn:${stack.partition}:logs:${stack.region}:${stack.account}:log-group:/aws/bedrock-agentcore/evaluations/*`],
+      }),
+    );
+
+    this.executionRole.addToPolicy(
+      new PolicyStatement({
+        sid: 'CloudWatchIndexPolicy',
+        effect: Effect.ALLOW,
+        actions: ['logs:DescribeIndexPolicies', 'logs:PutIndexPolicy'],
+        resources: [`arn:${stack.partition}:logs:${stack.region}:${stack.account}:log-group:aws/spans`],
+      }),
+    );
+
+    this.executionRole.addToPolicy(
+      new PolicyStatement({
+        sid: 'BedrockModelInvocation',
+        effect: Effect.ALLOW,
+        actions: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream'],
+        resources: ['*'],
+      }),
+    );
+
+    const evaluatorConfigs = EvalsConfig.evaluators.map((evaluatorId) => ({ evaluatorId }));
+    const evaluationConfigName = getEvalsConfigName(environment);
+
+    const evaluationConfig = {
+      onlineEvaluationConfigName: evaluationConfigName,
+      evaluators: evaluatorConfigs,
+      dataSourceConfig: {
+        cloudWatchLogs: {
+          logGroupNames: [traceLogGroupName],
+          serviceNames: [traceServiceName],
+        },
+      },
+      evaluationExecutionRoleArn: this.executionRole.roleArn,
+      enableOnCreate: true,
+      rule: {
+        samplingConfig: {
+          samplingPercentage: EvalsConfig.samplingPercentage,
+        },
+        sessionConfig: {
+          sessionTimeoutMinutes: EvalsConfig.sessionTimeoutMinutes,
+        },
+      },
+      description: `Online evaluation config for ${environment} environment`,
+    };
+
+    const evaluationConfigResource = new AwsCustomResource(this, 'Resource', {
+      resourceType: 'Custom::BedrockAgentCoreOnlineEvaluation',
+      installLatestAwsSdk: true,
+      onCreate: {
+        service: 'bedrock-agentcore-control',
+        action: 'CreateOnlineEvaluationConfig',
+        parameters: evaluationConfig,
+        physicalResourceId: PhysicalResourceId.fromResponse('onlineEvaluationConfigId'),
+      },
+      onUpdate: {
+        service: 'bedrock-agentcore-control',
+        action: 'UpdateOnlineEvaluationConfig',
+        parameters: {
+          onlineEvaluationConfigId: new PhysicalResourceIdReference(),
+          evaluators: evaluatorConfigs,
+          rule: evaluationConfig.rule,
+          description: evaluationConfig.description,
+        },
+        physicalResourceId: PhysicalResourceId.fromResponse('onlineEvaluationConfigId'),
+      },
+      onDelete: {
+        service: 'bedrock-agentcore-control',
+        action: 'DeleteOnlineEvaluationConfig',
+        parameters: {
+          onlineEvaluationConfigId: new PhysicalResourceIdReference(),
+        },
+      },
+      policy: AwsCustomResourcePolicy.fromStatements([
+        new PolicyStatement({
+          sid: 'BedrockAgentCoreAdmin',
+          effect: Effect.ALLOW,
+          actions: [
+            'bedrock-agentcore:CreateOnlineEvaluationConfig',
+            'bedrock-agentcore:GetOnlineEvaluationConfig',
+            'bedrock-agentcore:UpdateOnlineEvaluationConfig',
+            'bedrock-agentcore:DeleteOnlineEvaluationConfig',
+            'bedrock-agentcore:ListOnlineEvaluationConfigs',
+          ],
+          resources: ['*'],
+        }),
+        new PolicyStatement({
+          sid: 'PassRole',
+          effect: Effect.ALLOW,
+          actions: ['iam:PassRole'],
+          resources: [this.executionRole.roleArn],
+        }),
+        new PolicyStatement({
+          sid: 'CloudWatchIndexPermissions',
+          effect: Effect.ALLOW,
+          actions: ['logs:DescribeIndexPolicies', 'logs:PutIndexPolicy', 'logs:CreateLogGroup'],
+          resources: ['*'],
+        }),
+      ]),
+    });
+
+    this.configId = evaluationConfigResource.getResponseField('onlineEvaluationConfigId');
+    this.configArn = evaluationConfigResource.getResponseField('onlineEvaluationConfigArn');
+
+    this.applyNagSuppressions(evaluationConfigResource);
+  }
+
+  private applyNagSuppressions(evaluationConfigResource: AwsCustomResource): void {
+    NagSuppressions.addResourceSuppressions(
+      this.executionRole,
+      [
+        {
+          id: 'AwsSolutions-IAM5',
+          reason:
+            'Wildcard permissions required for CloudWatch Logs read operations (DescribeLogGroups, GetQueryResults, StartQuery) as log groups are dynamically created. Bedrock model invocation requires wildcard as models are global resources.',
+        },
+      ],
+      true,
+    );
+
+    NagSuppressions.addResourceSuppressions(
+      evaluationConfigResource,
+      [
+        {
+          id: 'AwsSolutions-IAM5',
+          reason:
+            'Wildcard permissions required for bedrock-agentcore evaluation config management and CloudWatch index operations. Resources are dynamically created and cannot be known at deployment time.',
+        },
+        {
+          id: 'AwsSolutions-IAM4',
+          reason: 'AWS managed policy used by AwsCustomResource Lambda for basic execution permissions.',
+        },
+        {
+          id: 'AwsSolutions-L1',
+          reason: 'Lambda runtime version is managed by AwsCustomResource construct.',
+        },
+      ],
+      true,
+    );
+  }
+}

--- a/infra/test/evals-config.spec.ts
+++ b/infra/test/evals-config.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { EvalsConfig, getEvalsConfigName } from '../constants/evals-config';
+
+describe('Evals Config', () => {
+  describe('getEvalsConfigName', () => {
+    it('should return correct pattern for dev environment', () => {
+      expect(getEvalsConfigName('dev')).toBe('cost_optimizer_eval_dev');
+    });
+
+    it('should return correct pattern for prod environment', () => {
+      expect(getEvalsConfigName('prod')).toBe('cost_optimizer_eval_prod');
+    });
+  });
+
+  describe('EvalsConfig constants', () => {
+    it('should have samplingPercentage set to 100', () => {
+      expect(EvalsConfig.samplingPercentage).toBe(100);
+    });
+
+    it('should have sessionTimeoutMinutes set to 5', () => {
+      expect(EvalsConfig.sessionTimeoutMinutes).toBe(5);
+    });
+
+    it('should have 10 built-in evaluators', () => {
+      expect(EvalsConfig.evaluators).toHaveLength(10);
+    });
+
+    it('should include all required evaluators', () => {
+      const expectedEvaluators = [
+        'Builtin.ToolSelectionAccuracy',
+        'Builtin.ToolParameterAccuracy',
+        'Builtin.Correctness',
+        'Builtin.Helpfulness',
+        'Builtin.Conciseness',
+        'Builtin.InstructionFollowing',
+        'Builtin.ResponseRelevance',
+        'Builtin.Coherence',
+        'Builtin.Faithfulness',
+        'Builtin.GoalSuccessRate',
+      ];
+      expect(EvalsConfig.evaluators).toEqual(expectedEvaluators);
+    });
+
+    it('should have defaultEndpointName set to DEFAULT', () => {
+      expect(EvalsConfig.defaultEndpointName).toBe('DEFAULT');
+    });
+  });
+});

--- a/infra/test/evals.spec.ts
+++ b/infra/test/evals.spec.ts
@@ -1,0 +1,304 @@
+import { App, Stack } from 'aws-cdk-lib';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { Match, Template } from 'aws-cdk-lib/assertions';
+
+import { Agent } from '../lib/agent';
+import { Evals } from '../lib/evals';
+
+/**
+ * Creates a test stack with Agent and Evals constructs for testing
+ */
+function createEvalsTestStack() {
+  const app = new App();
+  const stack = new Stack(app, 'TestStack', {
+    env: { account: '123456789012', region: 'us-east-1' },
+  });
+
+  const agent = new Agent(stack, 'TestAgent', {
+    agentRuntimeName: 'testRuntime_dev_v1',
+    description: 'Test agent for evals testing',
+    environment: 'dev',
+    modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
+    inferenceProfileRegion: 'us',
+  });
+
+  const evals = new Evals(stack, 'TestEvals', {
+    agent,
+    environment: 'dev',
+  });
+
+  const template = Template.fromStack(stack);
+
+  return { app, stack, agent, evals, template };
+}
+
+describe('Evals Construct', () => {
+  let template: Template;
+
+  beforeEach(() => {
+    const testStack = createEvalsTestStack();
+    template = testStack.template;
+  });
+
+  describe('Execution Role Trust Policy', () => {
+    it('should create execution role with bedrock-agentcore.amazonaws.com trust policy', () => {
+      template.hasResourceProperties('AWS::IAM::Role', {
+        AssumeRolePolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Action: 'sts:AssumeRole',
+              Effect: 'Allow',
+              Principal: {
+                Service: 'bedrock-agentcore.amazonaws.com',
+              },
+            }),
+          ]),
+        },
+      });
+    });
+
+    it('should include aws:SourceAccount condition in trust policy', () => {
+      template.hasResourceProperties('AWS::IAM::Role', {
+        AssumeRolePolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Condition: Match.objectLike({
+                StringEquals: Match.objectLike({
+                  'aws:SourceAccount': '123456789012',
+                }),
+              }),
+            }),
+          ]),
+        },
+      });
+    });
+
+    it('should include aws:ResourceAccount condition in trust policy', () => {
+      template.hasResourceProperties('AWS::IAM::Role', {
+        AssumeRolePolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Condition: Match.objectLike({
+                StringEquals: Match.objectLike({
+                  'aws:ResourceAccount': '123456789012',
+                }),
+              }),
+            }),
+          ]),
+        },
+      });
+    });
+
+    it('should include ArnLike condition for evaluator and online-evaluation-config', () => {
+      // Verify the role has ArnLike condition - checking the structure exists
+      template.hasResourceProperties('AWS::IAM::Role', {
+        AssumeRolePolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Condition: Match.objectLike({
+                ArnLike: Match.objectLike({
+                  'aws:SourceArn': Match.anyValue(),
+                }),
+              }),
+            }),
+          ]),
+        },
+      });
+    });
+  });
+
+  describe('Execution Role CloudWatch Logs Read Permissions', () => {
+    it('should have CloudWatch Logs read permissions with correct actions', () => {
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        PolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Sid: 'CloudWatchLogsRead',
+              Effect: 'Allow',
+              Action: ['logs:DescribeLogGroups', 'logs:GetQueryResults', 'logs:StartQuery'],
+              Resource: '*',
+            }),
+          ]),
+        },
+      });
+    });
+  });
+
+  describe('Execution Role CloudWatch Logs Write Permissions', () => {
+    it('should have CloudWatch Logs write permissions for evaluations log group', () => {
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        PolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Sid: 'CloudWatchLogsWrite',
+              Effect: 'Allow',
+              Action: ['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents'],
+            }),
+          ]),
+        },
+      });
+    });
+
+    it('should scope CloudWatch Logs write to /aws/bedrock-agentcore/evaluations/*', () => {
+      // Find the policy with CloudWatchLogsWrite statement and verify resource pattern
+      const policies = template.findResources('AWS::IAM::Policy');
+      const policyWithLogsWrite = Object.values(policies).find((policy) => {
+        const statements = (policy as { Properties: { PolicyDocument: { Statement: Array<{ Sid?: string }> } } }).Properties?.PolicyDocument
+          ?.Statement;
+        return statements?.some((stmt) => stmt.Sid === 'CloudWatchLogsWrite');
+      });
+
+      expect(policyWithLogsWrite).toBeDefined();
+      const statements = (
+        policyWithLogsWrite as { Properties: { PolicyDocument: { Statement: Array<{ Sid?: string; Resource?: unknown }> } } }
+      ).Properties.PolicyDocument.Statement;
+      const logsWriteStmt = statements.find((stmt) => stmt.Sid === 'CloudWatchLogsWrite');
+      const resourceStr = JSON.stringify(logsWriteStmt?.Resource);
+      expect(resourceStr).toContain('/aws/bedrock-agentcore/evaluations/*');
+    });
+  });
+
+  describe('Execution Role CloudWatch Index Policy Permissions', () => {
+    it('should have CloudWatch index policy permissions', () => {
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        PolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Sid: 'CloudWatchIndexPolicy',
+              Effect: 'Allow',
+              Action: ['logs:DescribeIndexPolicies', 'logs:PutIndexPolicy'],
+            }),
+          ]),
+        },
+      });
+    });
+
+    it('should scope CloudWatch index policy to aws/spans log group', () => {
+      // Find the policy with CloudWatchIndexPolicy statement and verify resource pattern
+      const policies = template.findResources('AWS::IAM::Policy');
+      const policyWithIndexPolicy = Object.values(policies).find((policy) => {
+        const statements = (policy as { Properties: { PolicyDocument: { Statement: Array<{ Sid?: string }> } } }).Properties?.PolicyDocument
+          ?.Statement;
+        return statements?.some((stmt) => stmt.Sid === 'CloudWatchIndexPolicy');
+      });
+
+      expect(policyWithIndexPolicy).toBeDefined();
+      const statements = (
+        policyWithIndexPolicy as { Properties: { PolicyDocument: { Statement: Array<{ Sid?: string; Resource?: unknown }> } } }
+      ).Properties.PolicyDocument.Statement;
+      const indexPolicyStmt = statements.find((stmt) => stmt.Sid === 'CloudWatchIndexPolicy');
+      const resourceStr = JSON.stringify(indexPolicyStmt?.Resource);
+      expect(resourceStr).toContain('log-group:aws/spans');
+    });
+  });
+
+  describe('Execution Role Bedrock Model Permissions', () => {
+    it('should have Bedrock model invocation permissions', () => {
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        PolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Sid: 'BedrockModelInvocation',
+              Effect: 'Allow',
+              Action: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream'],
+              Resource: '*',
+            }),
+          ]),
+        },
+      });
+    });
+  });
+
+  describe('AwsCustomResource Configuration', () => {
+    it('should create AwsCustomResource with Custom::BedrockAgentCoreOnlineEvaluation type', () => {
+      template.hasResource('Custom::BedrockAgentCoreOnlineEvaluation', {});
+    });
+
+    it('should configure onCreate with CreateOnlineEvaluationConfig action', () => {
+      const resources = template.findResources('Custom::BedrockAgentCoreOnlineEvaluation');
+      expect(Object.keys(resources).length).toBeGreaterThan(0);
+
+      // The Create property is a Fn::Join that contains the SDK call configuration as JSON
+      const resource = Object.values(resources)[0] as { Properties?: { Create?: unknown } };
+      expect(resource.Properties?.Create).toBeDefined();
+      const createStr = JSON.stringify(resource.Properties!.Create);
+      expect(createStr).toContain('bedrock-agentcore-control');
+      expect(createStr).toContain('CreateOnlineEvaluationConfig');
+    });
+
+    it('should configure onUpdate with UpdateOnlineEvaluationConfig action', () => {
+      const resources = template.findResources('Custom::BedrockAgentCoreOnlineEvaluation');
+      const resource = Object.values(resources)[0] as { Properties?: { Update?: unknown } };
+      expect(resource.Properties?.Update).toBeDefined();
+      const updateStr = JSON.stringify(resource.Properties!.Update);
+      expect(updateStr).toContain('bedrock-agentcore-control');
+      expect(updateStr).toContain('UpdateOnlineEvaluationConfig');
+    });
+
+    it('should configure onDelete with DeleteOnlineEvaluationConfig action', () => {
+      const resources = template.findResources('Custom::BedrockAgentCoreOnlineEvaluation');
+      const resource = Object.values(resources)[0] as { Properties?: { Delete?: unknown } };
+      expect(resource.Properties?.Delete).toBeDefined();
+      const deleteStr = JSON.stringify(resource.Properties!.Delete);
+      expect(deleteStr).toContain('bedrock-agentcore-control');
+      expect(deleteStr).toContain('DeleteOnlineEvaluationConfig');
+    });
+  });
+
+  describe('AwsCustomResource Policy - Admin Permissions', () => {
+    it('should have bedrock-agentcore admin permissions', () => {
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        PolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Sid: 'BedrockAgentCoreAdmin',
+              Effect: 'Allow',
+              Action: Match.arrayWith([
+                'bedrock-agentcore:CreateOnlineEvaluationConfig',
+                'bedrock-agentcore:GetOnlineEvaluationConfig',
+                'bedrock-agentcore:UpdateOnlineEvaluationConfig',
+                'bedrock-agentcore:DeleteOnlineEvaluationConfig',
+                'bedrock-agentcore:ListOnlineEvaluationConfigs',
+              ]),
+              Resource: '*',
+            }),
+          ]),
+        },
+      });
+    });
+  });
+
+  describe('AwsCustomResource Policy - PassRole Permission', () => {
+    it('should have iam:PassRole permission for execution role', () => {
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        PolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Sid: 'PassRole',
+              Effect: 'Allow',
+              Action: 'iam:PassRole',
+            }),
+          ]),
+        },
+      });
+    });
+  });
+
+  describe('AwsCustomResource Policy - CloudWatch Index Permissions', () => {
+    it('should have CloudWatch index permissions for custom resource', () => {
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        PolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Sid: 'CloudWatchIndexPermissions',
+              Effect: 'Allow',
+              Action: Match.arrayWith(['logs:DescribeIndexPolicies', 'logs:PutIndexPolicy', 'logs:CreateLogGroup']),
+              Resource: '*',
+            }),
+          ]),
+        },
+      });
+    });
+  });
+});

--- a/scripts/build-deployment-package.sh
+++ b/scripts/build-deployment-package.sh
@@ -12,7 +12,8 @@ echo "Building AgentCore Runtime package..."
 
 mkdir -p infra/dist/build-agent
 
-uv pip compile pyproject.toml --group agents --output-file infra/dist/build-agent/requirements.txt --quiet
+# Export from lockfile to ensure consistent versions between local dev and deployment
+uv export --group agents --no-hashes --output-file infra/dist/build-agent/requirements.txt --quiet
 uv pip install \
   --target infra/dist/build-agent/ \
   --python-version 3.12 \


### PR DESCRIPTION
**Issue number:** closes #<replace with issue number>

## Summary

### Changes

Adds support for Bedrock AgentCore Online Evaluations using a CDK Custom Resource. This enables continuous evaluation of agent performance using 10 built-in evaluators (Tool Selection/Parameter Accuracy, Correctness, Helpfulness, Conciseness, Instruction Following, Response Relevance, Coherence, Faithfulness, Goal Success Rate).

Key changes:
- Add `Evals` construct (`lib/evals.ts`) that manages Online Evaluation configs via `AwsCustomResource`
- Add `evals-config.ts` with evaluation configuration constants (100% sampling, 5min session timeout)
- Add `enableEvals` prop to `InfraStack` (defaults to `true` for prod, `false` otherwise)
- Support override via `ENABLE_EVALS` env var or CDK context
- Add execution role with least-privilege IAM permissions for bedrock-agentcore service
- Add comprehensive unit tests for the Evals construct

This is a temporary implementation until `@aws-cdk/aws-bedrock-agentcore-alpha` publishes the L2 construct.

### User experience

**Before:** No automated evaluation of agent responses. Manual review required to assess agent quality.

**After:** Agent traces are automatically sampled and evaluated against 10 quality dimensions. Evaluation results are written to CloudWatch Logs at `/aws/bedrock-agentcore/evaluations/*` for monitoring and analysis.

Usage:
```bash
# Enable evals in dev
ENABLE_EVALS=true make cdk-deploy

# Disable evals (default for dev)
make cdk-deploy

# Prod always has evals enabled by default
ENVIRONMENT=prod make cdk-deploy
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
