### PR TITLE
feat(infra): configure environment-specific settings and upgrade to Claude Sonnet 4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,16 +100,22 @@ Set these environment variables (or use defaults):
 |----------|-------------|---------|
 | `ENVIRONMENT` | Environment name (`dev`, `staging`, `prod`) | `dev` |
 | `RUNTIME_VERSION` | Version suffix for runtime naming | `v2` |
-| `MODEL_ID` | Amazon Bedrock model ID | Claude Sonnet 4 |
+| `MODEL_ID` | Amazon Bedrock model ID | Claude Sonnet 4.5 |
 | `TTL_DAYS` | Amazon DynamoDB record retention | `30` |
 | `ENABLE_EVALS` | Enable Online Evaluations | `true` in prod only |
+| `ENABLE_SCHEDULED_TRIGGER` | Enable daily scheduled trigger (6am UTC) | `true` in prod only |
 
 ### Environment-Based Features
 
+By default, the scheduled agent trigger is disabled in `dev` and `staging` environments to avoid unnecessary costs. You'll need to invoke the agent manually using `make trigger-workflow`. The daily 6am UTC schedule is only enabled if you set `ENVIRONMENT` to `prod`.
+
+Online Evaluations (AgentCore Evals) are also disabled by default except in `prod`. To enable them in other environments, set `ENABLE_EVALS=true` when deploying.
+
 | Feature | dev | staging | prod |
 |---------|-----|---------|------|
+| Scheduled Trigger (6am UTC) | ❌ | ❌ | ✅ |
+| Manual Trigger | ✅ | ✅ | ❌ |
 | Online Evaluations | ❌ | ❌ | ✅ |
-| Manual Trigger | ✅ | ❌ | ❌ |
 
 **Deploy to production:**
 ```bash
@@ -119,6 +125,11 @@ ENVIRONMENT=prod make cdk-deploy
 **Override evals (e.g., enable in dev for testing):**
 ```bash
 ENVIRONMENT=dev ENABLE_EVALS=true make cdk-deploy
+```
+
+**Override scheduled trigger (e.g., enable in staging):**
+```bash
+ENVIRONMENT=staging ENABLE_SCHEDULED_TRIGGER=true make cdk-deploy
 ```
 
 For more on Online Evaluations, see the [AgentCore Evaluations documentation](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/evaluations.html).

--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -19,11 +19,16 @@ const enableEvals =
       ? enableEvalsContext === true || enableEvalsContext === 'true'
       : environment === 'prod';
 
+// Enable scheduled trigger: default to true only for prod
+const enableScheduledTriggerEnv = process.env.ENABLE_SCHEDULED_TRIGGER;
+const enableScheduledTrigger = enableScheduledTriggerEnv !== undefined ? enableScheduledTriggerEnv === 'true' : environment === 'prod';
+
 new InfraStack(app, 'InfraStack', {
   description: InfraConfig.stackDescription,
   environment,
   runtimeVersion,
-  enableManualTrigger: environment === 'dev',
+  enableScheduledTrigger,
+  enableManualTrigger: environment !== 'prod', // dev and staging get manual trigger, prod does not
   enableEvals,
 });
 

--- a/infra/constants/infra-config.ts
+++ b/infra/constants/infra-config.ts
@@ -12,10 +12,10 @@ export type CrossRegionProfile = 'us' | 'eu' | 'apac' | 'global' | null;
 export const InfraConfig = {
   /**
    * Bedrock model ID to use for the agent
-   * Default: Claude Sonnet 4
+   * Default: Claude Sonnet 4.5
    * Note: Do not include region prefix (us./eu.) - use crossRegionInferenceProfile instead
    */
-  modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
+  modelId: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
 
   /**
    * Bedrock cross-region inference profile prefix

--- a/infra/lib/agent.ts
+++ b/infra/lib/agent.ts
@@ -28,7 +28,7 @@ export interface AgentProps {
   environmentVariables?: { [key: string]: string };
 
   /**
-   * Bedrock model ID (e.g., 'anthropic.claude-sonnet-4-20250514-v1:0')
+   * Bedrock model ID (e.g., 'anthropic.claude-sonnet-4-5-20250929-v1:0')
    */
   modelId: string;
 

--- a/infra/test/evals.spec.ts
+++ b/infra/test/evals.spec.ts
@@ -20,7 +20,7 @@ function createEvalsTestStack() {
     agentRuntimeName: 'testRuntime_dev_v1',
     description: 'Test agent for evals testing',
     environment: 'dev',
-    modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
+    modelId: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
     inferenceProfileRegion: 'us',
   });
 
@@ -311,6 +311,7 @@ describe('InfraStack Conditional Evals Creation', () => {
       const stack = new InfraStack(app, 'TestStack', {
         environment: 'dev',
         runtimeVersion: 'v2',
+        enableScheduledTrigger: false,
         enableManualTrigger: false,
         enableEvals: true,
       });
@@ -325,6 +326,7 @@ describe('InfraStack Conditional Evals Creation', () => {
       const stack = new InfraStack(app, 'TestStack', {
         environment: 'dev',
         runtimeVersion: 'v2',
+        enableScheduledTrigger: false,
         enableManualTrigger: false,
         enableEvals: true,
       });
@@ -337,6 +339,7 @@ describe('InfraStack Conditional Evals Creation', () => {
       const stack = new InfraStack(app, 'TestStack', {
         environment: 'dev',
         runtimeVersion: 'v2',
+        enableScheduledTrigger: false,
         enableManualTrigger: false,
         enableEvals: true,
       });
@@ -355,6 +358,7 @@ describe('InfraStack Conditional Evals Creation', () => {
       const stack = new InfraStack(app, 'TestStack', {
         environment: 'dev',
         runtimeVersion: 'v2',
+        enableScheduledTrigger: false,
         enableManualTrigger: false,
         enableEvals: false,
       });
@@ -370,6 +374,7 @@ describe('InfraStack Conditional Evals Creation', () => {
       const stack = new InfraStack(app, 'TestStack', {
         environment: 'dev',
         runtimeVersion: 'v2',
+        enableScheduledTrigger: false,
         enableManualTrigger: false,
         enableEvals: false,
       });
@@ -382,6 +387,7 @@ describe('InfraStack Conditional Evals Creation', () => {
       const stack = new InfraStack(app, 'TestStack', {
         environment: 'dev',
         runtimeVersion: 'v2',
+        enableScheduledTrigger: false,
         enableManualTrigger: false,
         enableEvals: false,
       });
@@ -391,21 +397,6 @@ describe('InfraStack Conditional Evals Creation', () => {
       const outputs = template.findOutputs('*');
       expect(Object.keys(outputs).some((key) => key.includes('EvaluationConfigId'))).toBe(false);
       expect(Object.keys(outputs).some((key) => key.includes('EvaluationConfigArn'))).toBe(false);
-    });
-  });
-
-  describe('default enableEvals behavior based on environment', () => {
-    it('should not create Evals when enableEvals is undefined', () => {
-      const app = new App();
-      const stack = new InfraStack(app, 'TestStack', {
-        environment: 'dev',
-        runtimeVersion: 'v2',
-        enableManualTrigger: false,
-        // enableEvals not specified - should be treated as falsy
-      });
-
-      // When enableEvals is undefined, it's falsy so evals should not be created
-      expect(stack.evals).toBeUndefined();
     });
   });
 });

--- a/infra/test/model-id-construction.spec.ts
+++ b/infra/test/model-id-construction.spec.ts
@@ -42,13 +42,13 @@ describe('Model ID Construction Logic', () => {
   it('should construct modelId with region prefix when inferenceProfileRegion is set', () => {
     const actualModelId = extractModelId(invokeStatement.Resource, ':inference-profile/');
 
-    expect(actualModelId).toBe('us.anthropic.claude-sonnet-4-20250514-v1:0');
+    expect(actualModelId).toBe('us.anthropic.claude-sonnet-4-5-20250929-v1:0');
   });
 
   it('should use base modelId without prefix in foundation model ARN', () => {
     const foundationModelId = extractModelId(invokeStatement.Resource, ':foundation-model/');
 
-    expect(foundationModelId).toBe('anthropic.claude-sonnet-4-20250514-v1:0');
+    expect(foundationModelId).toBe('anthropic.claude-sonnet-4-5-20250929-v1:0');
     expect(foundationModelId).not.toContain('us.');
   });
 
@@ -59,14 +59,14 @@ describe('Model ID Construction Logic', () => {
     new Agent(stack, 'TestAgent', {
       agentRuntimeName: 'testAgent_dev_v1',
       environment: 'dev',
-      modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
+      modelId: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
       inferenceProfileRegion: null,
     });
 
     const agentTemplate = Template.fromStack(stack);
     const stmt = getInvokeStatement(agentTemplate);
 
-    expect(extractModelId(stmt.Resource, ':inference-profile/')).toBe('anthropic.claude-sonnet-4-20250514-v1:0');
-    expect(extractModelId(stmt.Resource, ':foundation-model/')).toBe('anthropic.claude-sonnet-4-20250514-v1:0');
+    expect(extractModelId(stmt.Resource, ':inference-profile/')).toBe('anthropic.claude-sonnet-4-5-20250929-v1:0');
+    expect(extractModelId(stmt.Resource, ':foundation-model/')).toBe('anthropic.claude-sonnet-4-5-20250929-v1:0');
   });
 });

--- a/infra/test/setup.ts
+++ b/infra/test/setup.ts
@@ -27,7 +27,9 @@ export function createTestStack(enableManualTrigger = true) {
   const stack = new InfraStack(app, 'TestStack', {
     environment: 'dev',
     runtimeVersion: 'v2',
+    enableScheduledTrigger: true,
     enableManualTrigger,
+    enableEvals: false,
   });
   const template = Template.fromStack(stack);
 

--- a/scripts/run-agent-locally.sh
+++ b/scripts/run-agent-locally.sh
@@ -42,7 +42,7 @@ fi
 
 # Set environment variables for the agent
 export AWS_REGION="$AWS_REGION"
-export MODEL_ID="${MODEL_ID:-us.anthropic.claude-sonnet-4-20250514-v1:0}"
+export MODEL_ID="${MODEL_ID:-us.anthropic.claude-sonnet-4-5-20250929-v1:0}"
 export TTL_DAYS="${TTL_DAYS:-30}"
 export BYPASS_TOOL_CONSENT="true"
 

--- a/src/shared/constants.py
+++ b/src/shared/constants.py
@@ -7,7 +7,7 @@ making them easy to find, update, and maintain.
 
 # AWS Configuration Defaults
 DEFAULT_AWS_REGION = "us-east-1"
-DEFAULT_MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+DEFAULT_MODEL_ID = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
 DEFAULT_TTL_DAYS = 30
 
 # Boto3 Configuration Defaults

--- a/tests/test_shared_config.py
+++ b/tests/test_shared_config.py
@@ -46,7 +46,7 @@ class TestAppConfigFromEnv:
             assert config.s3_bucket_name == "test-bucket"
             assert config.journal_table_name == "test-table"
             assert config.aws_region == "us-east-1"
-            assert config.model_id == "us.anthropic.claude-sonnet-4-20250514-v1:0"
+            assert config.model_id == "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
             assert config.ttl_days == 30
 
     def test_raises_error_when_s3_bucket_name_missing(self):


### PR DESCRIPTION
## Summary

### Changes

Configures environment-specific deployment settings and upgrades the model:

- Added `enableScheduledTrigger` prop to `InfraStackProps` to control the daily 6am UTC scheduled EventBridge rule
- Made all feature flags (`enableScheduledTrigger`, `enableManualTrigger`, `enableEvals`) required and explicitly configured in `infra.ts`
- Upgraded model from Claude Sonnet 4 (`anthropic.claude-sonnet-4-20250514-v1:0`) to Claude Sonnet 4.5 (`anthropic.claude-sonnet-4-5-20250929-v1:0`)
- Updated README with environment configuration documentation

Environment defaults:

| Feature | dev | staging | prod |
|---------|-----|---------|------|
| Scheduled Trigger (6am UTC) | ❌ | ❌ | ✅ |
| Manual Trigger | ✅ | ✅ | ❌ |
| Online Evaluations | ❌ | ❌ | ✅ |

All flags can be overridden via environment variables (`ENABLE_SCHEDULED_TRIGGER`, `ENABLE_EVALS`).

### User experience

**Before:** Scheduled trigger rule was always deployed regardless of environment. Staging would run daily agent invocations unnecessarily. Model was Claude Sonnet 4.

**After:** Staging and dev environments only have manual triggers for on-demand testing. Scheduled runs and online evals are reserved for prod, reducing costs. Model upgraded to Claude Sonnet 4.5 for improved performance.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
