### PR TITLE
ci: add semantic PR config with titleOnly validation

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,1 @@
+titleOnly: true


### PR DESCRIPTION
## Summary
- Adds `.github/semantic.yml` with `titleOnly: true` to configure the Semantic PRs GitHub App
- Validates only PR titles (not individual commit messages), matching the approach used by [aws-powertools](https://github.com/aws-powertools/powertools-lambda-java)
- Reduces issues with the Semantic PR check getting stuck after branch rebases (Ezard/semantic-prs#1057)

## Test plan
- [ ] Verify Semantic PR check passes on this PR
- [ ] Verify Dependabot PRs no longer have stuck Semantic PR checks after rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)